### PR TITLE
fix: 작가 프로필 수정 redirect 경로와 view 이름을 명세에 맞게 수정

### DIFF
--- a/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerProfileController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerProfileController.java
@@ -20,7 +20,7 @@ public class PhotographerProfileController {
         PhotographerProfileResponse response = photographerProfileService.getProfileForm(photographerId);
 
         model.addAttribute("profile", response);
-        return "photographer/editProfile";
+        return "photographer/editProfileForm";
     }
 
     @PostMapping("/edit")
@@ -31,11 +31,11 @@ public class PhotographerProfileController {
     ) {
         try {
             photographerProfileService.createOrUpdateProfile(photographerId, request);
-            return "redirect:/photographer/" + photographerId;
+            return "redirect:/photographer/" + photographerId + "/profile";
         } catch (IllegalArgumentException e) {
             model.addAttribute("errorMessage", e.getMessage());
             model.addAttribute("profile", request);
-            return "photographer/editProfile";
+            return "photographer/editProfileForm";
         }
     }
 }


### PR DESCRIPTION
## 작업 내용
- `PhotographerProfileController`의 프로필 수정 흐름을 명세와 정합되도록 수정했습니다.
  - 프로필 수정 POST 성공 시 리다이렉트 경로 수정
  - 프로필 수정 GET/POST 실패 시 반환 뷰 이름 수정 및 통일

## 상세 변경 사항
### 1) 리다이렉트 경로 수정
- 변경 전: `redirect:/photographer/{photographerId}`
- 변경 후: `redirect:/photographer/{photographerId}/profile`

### 2) 뷰 이름 수정
- 변경 전: `photographer/editProfile`
- 변경 후: `photographer/editProfileForm`

> GET(`/photographer/{photographerId}/profile/edit`)과  
> POST 실패 케이스에서 동일하게 `photographer/editProfileForm`을 반환하도록 맞췄습니다.

## 명세 반영 포인트
- 프로필 수정 성공 응답 경로를 명세의 `redirect /photographer/{photographerId}/profile`에 맞춤
- 프로필 수정 화면 view 명을 명세의 `photographer/editProfileForm`으로 맞춤

## 테스트
- [x] 컴파일/빌드 확인

