### PR TITLE
feat: 작가 프로필 조회 GET 핸들러 추가

### DIFF
--- a/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerProfileController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerProfileController.java
@@ -15,6 +15,13 @@ public class PhotographerProfileController {
 
     private final PhotographerProfileService photographerProfileService;
 
+    @GetMapping
+    public String profilePage(@PathVariable Long photographerId, Model model) {
+        PhotographerProfileResponse response = photographerProfileService.getProfileForm(photographerId);
+        model.addAttribute("profile", response);
+        return "photographer/profile";
+    }
+
     @GetMapping("/edit")
     public String editProfilePage(@PathVariable Long photographerId, Model model) {
         PhotographerProfileResponse response = photographerProfileService.getProfileForm(photographerId);


### PR DESCRIPTION
## 작업 내용
- 작가 프로필 수정 완료 후 redirect되는 경로를 처리하기 위해 조회 GET 핸들러를 추가했습니다.

## 상세 변경 사항
- `GET /photographer/{photographerId}/profile` 엔드포인트 추가
- 서비스(`photographerProfileService.getProfileForm`)를 통해 프로필 데이터를 조회
- 모델에 `profile` 키로 데이터 바인딩
- 조회 뷰로 `photographer/profile` 반환

## 배경 / 목적
- 기존 프로필 수정 POST 성공 후 리다이렉트 경로가 `/photographer/{photographerId}/profile`로 변경됨
- 해당 경로를 처리하는 GET 핸들러가 없어 후속 화면 이동이 불가능했음
- 이번 PR에서 리다이렉트 도착지 경로를 우선 연결함

## 테스트
- [x] 컴파일/빌드 확인
- [x] 컨트롤러 파일 린트 오류 없음
- [ ] 템플릿(`photographer/profile`) 연동 후 브라우저 동작 확인

## 참고
- 상세 템플릿 연동 및 UI 확인은 HTML 작업 반영 후 진행 예정입니다