### PR TITLE
Feat: 포트폴리오 프로젝트 종류 연동 및 상세 수정 버튼 추가/삭제하기 기능 추가

### DIFF
--- a/src/main/java/com/pickkasso/pickkasso/user/controller/PortfolioController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/PortfolioController.java
@@ -50,7 +50,9 @@ public class PortfolioController {
         model.addAttribute("portfolioName", portfolioDto.name());
         model.addAttribute("portfolioDescription", portfolioDto.description());
         model.addAttribute("portfolioTagNames", portfolioService.getPortfolioTagNames(photographerId, portfolioId));
+        model.addAttribute("portfolioProjectType", portfolioDto.projectType());
         model.addAttribute("photographerId", photographerId);
+        model.addAttribute("portfolioId", portfolioId);
         model.addAttribute("photographerNickname", "");
         model.addAttribute("photographerImgUrl", null);
         model.addAttribute("photographerRating", 0.0);

--- a/src/main/java/com/pickkasso/pickkasso/user/controller/PortfolioController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/PortfolioController.java
@@ -93,4 +93,17 @@ public class PortfolioController {
             return "photographer/editPortfolio";
         }
     }
+
+    @PostMapping("/{portfolioId}/delete")
+    public String deletePortfolio(
+            @PathVariable Long photographerId,
+            @PathVariable Long portfolioId
+    ) {
+        try {
+            portfolioService.deletePortfolio(photographerId, portfolioId);
+            return "redirect:/photographer/" + photographerId + "/profile";
+        } catch (IllegalArgumentException e) {
+            return "redirect:/photographer/" + photographerId + "/portfolio/" + portfolioId;
+        }
+    }
 }

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/portfolio/PortfolioDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/portfolio/PortfolioDto.java
@@ -1,5 +1,7 @@
 package com.pickkasso.pickkasso.user.dto.portfolio;
 
+import com.pickkasso.pickkasso.user.entity.PortfolioProjectType;
+
 import java.time.LocalDate;
 import java.util.List;
 
@@ -9,6 +11,7 @@ public record PortfolioDto(
         LocalDate startTime,
         LocalDate endTime,
         List<PortfolioImgDto> portfolioImgDtoList,
-        List<Long> tagIdList
+        List<Long> tagIdList,
+        PortfolioProjectType projectType
 ) {
 }

--- a/src/main/java/com/pickkasso/pickkasso/user/entity/Portfolio.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/entity/Portfolio.java
@@ -31,6 +31,10 @@ public class Portfolio {
     @Column(name = "description")
     private String description;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "project_type")
+    private PortfolioProjectType projectType;
+
     @ManyToMany
     @JoinTable(
             name = "t_portfolio_tag",
@@ -43,23 +47,27 @@ public class Portfolio {
     private Portfolio(
         Photographer photographer,
         String name,
-        String description) {
+        String description,
+        PortfolioProjectType projectType) {
         this.photographer = photographer;
         this.name = name;
         this.description = description;
+        this.projectType = projectType;
     }
 
     //== 생성 method ==//
     public static Portfolio createPortfolio(
         Photographer photographer,
         String name,
-        String description) {
-        return new Portfolio(photographer, name, description);
+        String description,
+        PortfolioProjectType projectType) {
+        return new Portfolio(photographer, name, description, projectType);
     }
 
-    public void updatePortfolio(String name, String description) {
+    public void updatePortfolio(String name, String description, PortfolioProjectType projectType) {
         this.name = name;
         this.description = description;
+        this.projectType = projectType;
     }
 
     public void updateTags(List<Tag> tags) {

--- a/src/main/java/com/pickkasso/pickkasso/user/entity/PortfolioProjectType.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/entity/PortfolioProjectType.java
@@ -1,0 +1,13 @@
+package com.pickkasso.pickkasso.user.entity;
+
+public enum PortfolioProjectType {
+    PERSONAL,
+    COMMERCIAL;
+
+    public String getDisplayName() {
+        return switch (this) {
+            case PERSONAL -> "개인";
+            case COMMERCIAL -> "상업 프로젝트";
+        };
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/service/PortfolioService.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/service/PortfolioService.java
@@ -79,6 +79,12 @@ public class PortfolioService {
         portfolio.updateTags(getTags(dto.tagIdList()));
     }
 
+    public void deletePortfolio(Long photographerId, Long portfolioId) {
+        Portfolio portfolio = getOwnedPortfolio(photographerId, portfolioId);
+        portfolio.updateTags(List.of());
+        portfolioRepository.delete(portfolio);
+    }
+
     private Portfolio getOwnedPortfolio(Long photographerId, Long portfolioId) {
         return portfolioRepository.findByIdAndPhotographerId(portfolioId, photographerId)
                 .orElseThrow(() -> new IllegalArgumentException("포트폴리오를 찾을 수 없습니다."));

--- a/src/main/java/com/pickkasso/pickkasso/user/service/PortfolioService.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/service/PortfolioService.java
@@ -5,6 +5,7 @@ import com.pickkasso.pickkasso.global.tag.TagRepository;
 import com.pickkasso.pickkasso.user.dto.portfolio.PortfolioDto;
 import com.pickkasso.pickkasso.user.entity.Photographer;
 import com.pickkasso.pickkasso.user.entity.Portfolio;
+import com.pickkasso.pickkasso.user.entity.PortfolioProjectType;
 import com.pickkasso.pickkasso.user.repository.PhotographerRepository;
 import com.pickkasso.pickkasso.user.repository.PortfolioRepository;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +33,8 @@ public class PortfolioService {
                 null,
                 null,
                 null,
-                null
+                null,
+                PortfolioProjectType.PERSONAL
         );
     }
 
@@ -46,7 +48,8 @@ public class PortfolioService {
         Portfolio portfolio = Portfolio.createPortfolio(
                 photographer,
                 dto.name(),
-                dto.description()
+                dto.description(),
+                resolveProjectType(dto)
         );
         portfolio.updateTags(getTags(dto.tagIdList()));
 
@@ -72,7 +75,7 @@ public class PortfolioService {
         validatePortfolio(dto);
 
         Portfolio portfolio = getOwnedPortfolio(photographerId, portfolioId);
-        portfolio.updatePortfolio(dto.name(), dto.description());
+        portfolio.updatePortfolio(dto.name(), dto.description(), resolveProjectType(dto));
         portfolio.updateTags(getTags(dto.tagIdList()));
     }
 
@@ -88,8 +91,16 @@ public class PortfolioService {
                 null,
                 null,
                 null,
-                portfolio.getTags().stream().map(Tag::getId).toList()
+                portfolio.getTags().stream().map(Tag::getId).toList(),
+                portfolio.getProjectType()
         );
+    }
+
+    private PortfolioProjectType resolveProjectType(PortfolioDto dto) {
+        if (dto.projectType() == null) {
+            return PortfolioProjectType.PERSONAL;
+        }
+        return dto.projectType();
     }
 
     private List<Tag> getTags(List<Long> tagIds) {

--- a/src/main/resources/templates/photographer/editPortfolio.html
+++ b/src/main/resources/templates/photographer/editPortfolio.html
@@ -224,18 +224,32 @@
       </div>
 
       <!-- ─── 하단 버튼 ─────────────────────────────────── -->
-      <div class="flex items-center justify-end gap-3">
-        <a th:href="@{/photographer/{id}/profile/edit(id=${photographerId})}"
-           class="text-sm font-semibold text-[#888] border border-[#CCC] rounded-lg px-5 py-2.5 hover:border-[#888] transition-colors">
-          취소
-        </a>
-        <button type="submit"
-                class="text-sm font-semibold bg-white border border-[#1D3CFF] text-[#1D3CFF] rounded-lg px-6 py-2.5 hover:bg-[#1D3CFF] hover:text-white active:bg-[#1530E0] active:border-[#1530E0] transition-colors">
-          저장하기
+      <div class="flex items-center justify-between gap-3">
+        <button th:if="${portfolioId != null}"
+                type="button"
+                id="delete-portfolio-trigger"
+                class="text-sm font-semibold bg-white border border-red-300 text-red-600 rounded-lg px-5 py-2.5 hover:bg-red-50 transition-colors">
+          삭제하기
         </button>
+
+        <div class="ml-auto flex items-center gap-3">
+          <a th:href="@{/photographer/{id}/profile/edit(id=${photographerId})}"
+             class="text-sm font-semibold text-[#888] border border-[#CCC] rounded-lg px-5 py-2.5 hover:border-[#888] transition-colors">
+            취소
+          </a>
+          <button type="submit"
+                  class="text-sm font-semibold bg-white border border-[#1D3CFF] text-[#1D3CFF] rounded-lg px-6 py-2.5 hover:bg-[#1D3CFF] hover:text-white active:bg-[#1530E0] active:border-[#1530E0] transition-colors">
+            저장하기
+          </button>
+        </div>
       </div>
 
     </form>
+
+    <form th:if="${portfolioId != null}"
+          th:action="@{/photographer/{id}/portfolio/{portfolioId}/delete(id=${photographerId}, portfolioId=${portfolioId})}"
+          method="post"
+          id="delete-portfolio-form"></form>
   </div>
 
   <div id="month-picker-modal"
@@ -276,7 +290,61 @@
     </div>
   </div>
 
+  <div id="delete-confirm-modal"
+       class="fixed inset-0 z-50 hidden items-center justify-center bg-[#1A1A1A]/35 px-4">
+    <div class="w-full max-w-sm rounded-2xl border border-[#CCC] bg-white p-6 shadow-lg">
+      <h3 class="text-base font-semibold text-[#1A1A1A]">포트폴리오를 삭제할까요?</h3>
+      <p class="mt-2 text-sm text-[#666] leading-relaxed">
+        삭제한 포트폴리오는 복구할 수 없습니다.
+      </p>
+      <div class="mt-6 flex items-center justify-end gap-2">
+        <button type="button"
+                id="delete-confirm-cancel"
+                class="text-sm font-semibold text-[#888] border border-[#CCC] rounded-lg px-4 py-2 hover:border-[#888] transition-colors">
+          취소
+        </button>
+        <button type="button"
+                id="delete-confirm-submit"
+                class="text-sm font-semibold bg-white border border-red-300 text-red-600 rounded-lg px-4 py-2 hover:bg-red-50 transition-colors">
+          삭제
+        </button>
+      </div>
+    </div>
+  </div>
+
   <script>
+  // ── 삭제 확인 모달 ──────────────────────────────────────────────
+  (function () {
+    var trigger = document.getElementById('delete-portfolio-trigger');
+    var modal = document.getElementById('delete-confirm-modal');
+    var cancelButton = document.getElementById('delete-confirm-cancel');
+    var submitButton = document.getElementById('delete-confirm-submit');
+    var deleteForm = document.getElementById('delete-portfolio-form');
+
+    if (!trigger || !modal || !cancelButton || !submitButton || !deleteForm) return;
+
+    function openModal() {
+      modal.classList.remove('hidden');
+      modal.classList.add('flex');
+    }
+
+    function closeModal() {
+      modal.classList.add('hidden');
+      modal.classList.remove('flex');
+    }
+
+    trigger.addEventListener('click', openModal);
+    cancelButton.addEventListener('click', closeModal);
+    submitButton.addEventListener('click', function () {
+      deleteForm.submit();
+    });
+    modal.addEventListener('click', function (event) {
+      if (event.target === modal) {
+        closeModal();
+      }
+    });
+  })();
+
   // ── 프로젝트 기간 월 선택기 ───────────────────────────────────
   (function () {
     var modal = document.getElementById('month-picker-modal');

--- a/src/main/resources/templates/photographer/editPortfolio.html
+++ b/src/main/resources/templates/photographer/editPortfolio.html
@@ -70,26 +70,26 @@
 
           <!-- 프로젝트 종류 + 기간 -->
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <!-- 프로젝트 종류 — DTO 미대응, UI only -->
             <div>
               <label class="block text-sm font-medium text-[#444] mb-1.5">
                 프로젝트 종류
               </label>
               <div class="grid grid-cols-2 gap-2">
                 <label class="cursor-pointer">
-                  <input type="radio" name="projectType" value="PERSONAL" class="peer sr-only" checked>
+                  <input type="radio" name="projectType" value="PERSONAL" class="peer sr-only"
+                         th:checked="${portfolioDto.projectType == null or portfolioDto.projectType.name() == 'PERSONAL'}">
                   <span class="flex items-center justify-center rounded-lg border border-[#CCC] bg-[#F9FAFC] px-4 py-2.5 text-sm font-semibold text-[#444] transition-colors peer-checked:border-[#1D3CFF] peer-checked:bg-[#1D3CFF] peer-checked:text-white">
                     개인
                   </span>
                 </label>
                 <label class="cursor-pointer">
-                  <input type="radio" name="projectType" value="COMMERCIAL" class="peer sr-only">
+                  <input type="radio" name="projectType" value="COMMERCIAL" class="peer sr-only"
+                         th:checked="${portfolioDto.projectType != null and portfolioDto.projectType.name() == 'COMMERCIAL'}">
                   <span class="flex items-center justify-center rounded-lg border border-[#CCC] bg-[#F9FAFC] px-4 py-2.5 text-sm font-semibold text-[#444] transition-colors peer-checked:border-[#1D3CFF] peer-checked:bg-[#1D3CFF] peer-checked:text-white">
                     상업 프로젝트
                   </span>
                 </label>
               </div>
-              <p class="mt-1.5 text-xs text-[#888]">현재는 화면 선택만 제공되고 저장 연동은 준비 중입니다</p>
             </div>
             <!-- 프로젝트 기간 — DTO: startTime / endTime (LocalDate) -->
             <div>

--- a/src/main/resources/templates/photographer/portfolio-detail.html
+++ b/src/main/resources/templates/photographer/portfolio-detail.html
@@ -117,12 +117,21 @@
         <div>
           <p class="text-xs font-bold text-[#888] uppercase tracking-wide mb-2">프로젝트 종류</p>
           <div class="flex flex-wrap gap-2">
-            <span class="bg-[#F9FAFC] text-[#AAA] text-xs px-3 py-1 rounded-full border border-[#CCC]">준비 중</span>
+            <span th:if="${portfolioProjectType == null}"
+                  class="bg-[#F9FAFC] text-[#AAA] text-xs px-3 py-1 rounded-full border border-[#CCC]">준비 중</span>
+            <span th:if="${portfolioProjectType != null}"
+                  class="bg-[#EEF4FF] text-[#1D3CFF] text-xs px-3 py-1 rounded-full border border-[#C9DAFF]"
+                  th:text="${portfolioProjectType.displayName}">개인</span>
           </div>
         </div>
       </div>
 
       <!-- 예약 버튼 -->
+      <a th:href="@{/photographer/{id}/portfolio/{portfolioId}/edit(id=${photographerId}, portfolioId=${portfolioId})}"
+         class="block w-full bg-white border border-[#CCC] text-[#444] font-bold py-3.5 rounded-xl text-[15px] hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors text-center no-underline">
+        포트폴리오 수정하기
+      </a>
+
       <a th:href="@{/photographer/{id}/profile(id=${photographerId})}"
          class="block w-full bg-white border border-[#1D3CFF] text-[#1D3CFF] font-bold py-3.5 rounded-xl text-[15px] hover:bg-[#1D3CFF] hover:text-white active:bg-[#1530E0] active:border-[#1530E0] transition-colors text-center no-underline">
         이 작가에게 예약하기

--- a/src/test/java/com/pickkasso/pickkasso/user/service/PortfolioServiceTest.java
+++ b/src/test/java/com/pickkasso/pickkasso/user/service/PortfolioServiceTest.java
@@ -5,6 +5,7 @@ import com.pickkasso.pickkasso.user.entity.Account;
 import com.pickkasso.pickkasso.user.entity.Gender;
 import com.pickkasso.pickkasso.user.entity.Photographer;
 import com.pickkasso.pickkasso.user.entity.Portfolio;
+import com.pickkasso.pickkasso.user.entity.PortfolioProjectType;
 import com.pickkasso.pickkasso.user.entity.Role;
 import com.pickkasso.pickkasso.user.repository.AccountRepository;
 import com.pickkasso.pickkasso.user.repository.PhotographerRepository;
@@ -45,7 +46,8 @@ class PortfolioServiceTest {
                 null,
                 null,
                 null,
-                null
+                null,
+                PortfolioProjectType.COMMERCIAL
         );
 
         // when
@@ -56,6 +58,7 @@ class PortfolioServiceTest {
 
         assertThat(portfolio.getName()).isEqualTo("감성 데이트 스냅");
         assertThat(portfolio.getDescription()).isEqualTo("따뜻한 분위기의 포트폴리오");
+        assertThat(portfolio.getProjectType()).isEqualTo(PortfolioProjectType.COMMERCIAL);
     }
 
     private Photographer createTestPhotographer() {


### PR DESCRIPTION
## 작업 내용

### 1) 포트폴리오 프로젝트 종류 연동
- `PortfolioProjectType` enum 추가 (`PERSONAL`, `COMMERCIAL`)
- `Portfolio` 엔티티에 `projectType` 필드(`project_type`) 추가
- `PortfolioDto`에 `projectType` 필드 추가
- 생성/수정 서비스 로직에 `projectType` 반영 (null 시 `PERSONAL` 기본값)
- 상세 화면에서 프로젝트 종류 표시
  - 값 없으면 `준비 중`
  - 값 있으면 `개인 / 상업 프로젝트`

### 2) 포트폴리오 상세/수정 UX 보완
- 포트폴리오 상세 화면에 `수정하기` 버튼 추가
- 삭제 버튼 위치를 **수정 화면 하단 왼쪽**으로 변경
- 기본 `confirm` 대신 **커스텀 삭제 확인 모달** 적용

### 3) 포트폴리오 삭제 기능 추가
- `POST /photographer/{photographerId}/portfolio/{portfolioId}/delete`
- 소유 포트폴리오 검증 후 삭제
- 삭제 후 `/photographer/{photographerId}/profile` 리다이렉트
- 삭제 전 태그 연관관계 정리 후 삭제 처리

---

## DB 안내 (로컬 환경 차이 대응)

같은 코드여도 로컬 DB는 기존 실행 이력(수동 ALTER, ddl-auto=update 적용 시점, 기존 테이블 재사용)으로 스키마 상태가 다를 수 있습니다.  
아래 확인/보정 SQL 참고 부탁드립니다.

### 1) `project_type` 컬럼 확인/추가

**왜 필요한가**  
이번 작업에서 엔티티에 `projectType` 필드가 추가되어 DB에도 `t_portfolio.project_type` 컬럼이 필요합니다.

```sql
-- 컬럼 존재 확인
SHOW COLUMNS FROM t_portfolio LIKE 'project_type';

-- 컬럼이 없을 때만 실행
ALTER TABLE t_portfolio
  ADD COLUMN project_type VARCHAR(32) NULL;
```
## DB 보정 가이드

### 2) JPA IDENTITY 관련 PK(AUTO_INCREMENT) 보정 필요 시

#### 왜 필요한가
엔티티 PK가 `@GeneratedValue(strategy = IDENTITY)`인 경우, DB PK 컬럼은 `AUTO_INCREMENT`여야 합니다.  
해당 설정이 없으면 insert 시 DB가 PK를 자동 생성하지 못해 아래 에러가 발생할 수 있습니다.

- `Field '..._id' doesn't have a default value`

즉, JPA가 기대하는 “DB 자동 PK 생성”과 실제 DB 스키마를 맞추기 위한 보정입니다.

```sql
ALTER TABLE t_account
  MODIFY COLUMN account_id BIGINT NOT NULL AUTO_INCREMENT;

ALTER TABLE t_career
  MODIFY COLUMN career_id BIGINT NOT NULL AUTO_INCREMENT;

ALTER TABLE t_education
  MODIFY COLUMN education_id BIGINT NOT NULL AUTO_INCREMENT;
``` 
  ### 3) t_portfolio PK 보정 (FK가 있어 순서 중요)

#### 왜 필요한가
`t_portfolio_tag`가 `t_portfolio.portfolio_id`를 FK로 참조하고 있어,  
참조가 걸린 상태에서는 PK 컬럼 속성 변경이 차단됩니다.

따라서 아래 순서가 필요합니다.

1. FK 잠시 해제  
2. PK 컬럼 속성 보정 (`AUTO_INCREMENT`)  
3. FK 재생성

```sql
ALTER TABLE t_portfolio_tag
  DROP FOREIGN KEY FKdtbeg30s4erb73j7x4g0q1ayy;

ALTER TABLE t_portfolio
  MODIFY COLUMN portfolio_id BIGINT NOT NULL AUTO_INCREMENT;

ALTER TABLE t_portfolio_tag
  ADD CONSTRAINT FKdtbeg30s4erb73j7x4g0q1ayy
  FOREIGN KEY (portfolio_id) REFERENCES t_portfolio(portfolio_id);
```
 
## 테스트 체크리스트

- [x] 포트폴리오 생성 시 프로젝트 종류(`PERSONAL`/`COMMERCIAL`) 저장 확인
- [x] 포트폴리오 상세에서 프로젝트 종류 표시 확인
  - 값 있음: `개인` 또는 `상업 프로젝트`
  - 값 없음: `준비 중`
- [x] 포트폴리오 상세에서 `수정하기` 버튼 진입 확인
- [x] 포트폴리오 수정 화면 하단 왼쪽 `삭제하기` 버튼 노출 확인 (수정 모드에서만)
- [x] 삭제 확인 모달 동작 확인
- [x] 삭제 후 DB 반영 확인
  - [x] `t_portfolio`에서 대상 포트폴리오 행 삭제
  - [x] `t_portfolio_tag`에서 연관 매핑 삭제
  