### PR TITLE
feat: 회원가입 기능 개선 및 photographer 생성 로직 추가

### DIFF
--- a/src/main/java/com/pickkasso/pickkasso/user/auth/SecurityConfig.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/auth/SecurityConfig.java
@@ -20,7 +20,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
             .authorizeHttpRequests(auth -> auth
-                    .requestMatchers("/", "/login", "/signup/**", "/find-account","/css/**", "/js/**", "/images/**","/find-id/**", "/find-pw/**").permitAll()
+                    .requestMatchers("/", "/login", "/signup/**", "/find-account","/css/**", "/fonts/**","/js/**", "/images/**","/find-id/**", "/find-pw/**").permitAll()
                     .requestMatchers("/photographer/**").hasRole("PHOTOGRAPHER")
                     .requestMatchers("/member/**").hasRole("MEMBER")
                     .anyRequest().authenticated()

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/SignupDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/SignupDto.java
@@ -15,8 +15,8 @@ public class SignupDto {
 
     @Size(min = 8, message = "비밀번호는 8자 이상이어야 합니다.")
     @Pattern(
-            regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*]).+$",
-            message = "비밀번호는 대문자, 소문자, 숫자, 특수문자를 포함해야 합니다."
+            regexp = "^(?=.*[a-z])(?=.*\\d).{8,30}$",
+            message = "비밀번호는 소문자, 숫자를 포함해야 합니다."
     )
     private String password;
     private String passwordConfirm;

--- a/src/main/java/com/pickkasso/pickkasso/user/service/SignupService.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/service/SignupService.java
@@ -4,7 +4,10 @@ import com.pickkasso.pickkasso.user.dto.AccountDto;
 import com.pickkasso.pickkasso.user.dto.SignupDto;
 import com.pickkasso.pickkasso.user.entity.Account;
 import com.pickkasso.pickkasso.user.entity.Member;
+import com.pickkasso.pickkasso.user.entity.Photographer;
+import com.pickkasso.pickkasso.user.entity.Role;
 import com.pickkasso.pickkasso.user.repository.MemberRepository;
+import com.pickkasso.pickkasso.user.repository.PhotographerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -14,11 +17,12 @@ public class SignupService {
 
     private final MemberRepository memberRepository;
     private final AccountService accountService;
+    private final PhotographerRepository photographerRepository;
 
 
     public void signup(SignupDto dto) {
 
-        if (!dto.getPassword().matches("^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*]).{8,30}$")) {
+        if (!dto.getPassword().matches("^(?=.*[a-z])(?=.*\\d).{8,30}$")) {
             throw new IllegalStateException("비밀번호 규칙 위반");
         }
 
@@ -48,5 +52,18 @@ public class SignupService {
         );
 
         memberRepository.save(member);
+
+        if (dto.getRole() == Role.PHOTOGRAPHER) {
+            Photographer photographer = Photographer.createMember(
+                    account,
+                    dto.getEmail(),
+                    dto.getName(),
+                    dto.getGender(),
+                    dto.getPhone(),
+                    0
+            );
+            photographerRepository.save(photographer);
+        }
+
     }
 }

--- a/src/main/resources/templates/fragments/signup-form.html
+++ b/src/main/resources/templates/fragments/signup-form.html
@@ -86,8 +86,8 @@
             <label class="block text-sm font-medium text-[#444] mb-1.5">비밀번호</label>
             <input type="password" name="password" id="password"
                    required minlength="8" maxlength="30"
-                   pattern="^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*]).{8,30}$"
-                   title="비밀번호는 8~30자, 대문자/소문자/숫자/특수문자를 포함해야 합니다."
+                   pattern="^(?=.*[a-z])(?=.*\d).{8,30}$"
+                   title="비밀번호는 8~30자, 소문자와 숫자를 포함해야 합니다."
                    placeholder="8~30자"
                    class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-4 py-3 text-[#1A1A1A] placeholder-[#AAA] text-[15px] focus:outline-none focus:border-[#0097FF] focus:ring-1 focus:ring-[#0097FF]"/>
           </div>


### PR DESCRIPTION
## 작업 내용

* 기존 대문자/특수문자 포함 조건을 제거하고, 소문자와 숫자만 포함하도록 수정했습니다.
* 작가 회원가입 시 `t_photographer` 테이블에도 데이터가 저장되도록 로직을 추가했습니다.


## 변경 사항

* SignupDto: 비밀번호 검증 조건 수정
* SignupService:

  * 비밀번호 검증 조건 수정
  * 회원가입 시 역할에 따라 `t_photographer` 테이블 저장 로직 추가
* signup-form.html: pattern 및 안내 문구 수정

pull하시면 회원가입 한번 더 하시고 로그인 후에
http://localhost/photographer/{db에 저장된 id}/profile/edit
입력하시면 될 것 같습니다!

## 테스트

* [x] 회원가입 시 완화된 비밀번호로 입력 가능 확인
* [x] 일반회원 가입 시 `t_member`만 저장되는지 확인
* [x] 작가회원 가입 시 `t_member`, `t_photographer` 모두 저장되는지 확인

## 참고
