### PR TITLE
feat: 캐시 충전 모달 추가

### DIFF
--- a/src/main/java/com/pickkasso/pickkasso/user/cash/controller/CashController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/cash/controller/CashController.java
@@ -1,0 +1,35 @@
+package com.pickkasso.pickkasso.user.cash.controller;
+
+import com.pickkasso.pickkasso.user.cash.dto.CashChargeRequest;
+import com.pickkasso.pickkasso.user.cash.dto.CashChargeResponse;
+import com.pickkasso.pickkasso.user.cash.service.CashService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/cash")
+@RequiredArgsConstructor
+public class CashController {
+
+    private final CashService cashService;
+
+    @PostMapping("/charge")
+    public CashChargeResponse charge(@RequestBody CashChargeRequest req,
+                                     Authentication auth) {
+        if (auth == null || !auth.isAuthenticated()
+                || "anonymousUser".equals(auth.getName())) {
+            throw new AccessDeniedException("로그인이 필요합니다.");
+        }
+        return cashService.charge(auth.getName(), req.getAmount());
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleBadRequest(IllegalArgumentException e) {
+        return ResponseEntity.badRequest().body(Map.of("message", e.getMessage()));
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/cash/dto/CashChargeRequest.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/cash/dto/CashChargeRequest.java
@@ -1,0 +1,10 @@
+package com.pickkasso.pickkasso.user.cash.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CashChargeRequest {
+    private Integer amount;
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/cash/dto/CashChargeResponse.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/cash/dto/CashChargeResponse.java
@@ -1,0 +1,11 @@
+package com.pickkasso.pickkasso.user.cash.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CashChargeResponse {
+    private Long historyId;
+    private Integer newBalance;
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/cash/entity/CashHistory.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/cash/entity/CashHistory.java
@@ -1,0 +1,55 @@
+package com.pickkasso.pickkasso.user.cash.entity;
+
+import com.pickkasso.pickkasso.user.entity.Account;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "t_cash_history")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CashHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    private Account account;
+
+    @Column(nullable = false)
+    private Integer amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private CashHistoryType type;
+
+    @Column(name = "balance_after", nullable = false)
+    private Integer balanceAfter;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column
+    private String memo;
+
+    private CashHistory(Account account, int amount, CashHistoryType type, int balanceAfter, String memo) {
+        this.account = account;
+        this.amount = amount;
+        this.type = type;
+        this.balanceAfter = balanceAfter;
+        this.memo = memo;
+    }
+
+    public static CashHistory ofCharge(Account account, int amount, int balanceAfter) {
+        return new CashHistory(account, amount, CashHistoryType.CHARGE, balanceAfter,
+                "CHARGE preset " + amount);
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/cash/entity/CashHistoryType.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/cash/entity/CashHistoryType.java
@@ -1,0 +1,5 @@
+package com.pickkasso.pickkasso.user.cash.entity;
+
+public enum CashHistoryType {
+    CHARGE, USE, REFUND
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/cash/repository/CashHistoryRepository.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/cash/repository/CashHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.pickkasso.pickkasso.user.cash.repository;
+
+import com.pickkasso.pickkasso.user.cash.entity.CashHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CashHistoryRepository extends JpaRepository<CashHistory, Long> {
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/cash/service/CashService.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/cash/service/CashService.java
@@ -1,0 +1,58 @@
+package com.pickkasso.pickkasso.user.cash.service;
+
+import com.pickkasso.pickkasso.user.cash.dto.CashChargeRequest;
+import com.pickkasso.pickkasso.user.cash.dto.CashChargeResponse;
+import com.pickkasso.pickkasso.user.cash.entity.CashHistory;
+import com.pickkasso.pickkasso.user.cash.repository.CashHistoryRepository;
+import com.pickkasso.pickkasso.user.entity.Account;
+import com.pickkasso.pickkasso.user.entity.Member;
+import com.pickkasso.pickkasso.user.entity.Photographer;
+import com.pickkasso.pickkasso.user.entity.Role;
+import com.pickkasso.pickkasso.user.repository.AccountRepository;
+import com.pickkasso.pickkasso.user.repository.MemberRepository;
+import com.pickkasso.pickkasso.user.repository.PhotographerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class CashService {
+
+    private static final Set<Integer> PRESETS = Set.of(10_000, 30_000, 50_000, 100_000);
+
+    private final AccountRepository accountRepository;
+    private final MemberRepository memberRepository;
+    private final PhotographerRepository photographerRepository;
+    private final CashHistoryRepository cashHistoryRepository;
+
+    @Transactional
+    public CashChargeResponse charge(String username, Integer amount) {
+        if (amount == null || !PRESETS.contains(amount)) {
+            throw new IllegalArgumentException("허용되지 않은 충전 금액입니다.");
+        }
+
+        Account account = accountRepository.findByUsername(username);
+        if (account == null) {
+            throw new AccessDeniedException("계정을 찾을 수 없습니다.");
+        }
+
+        int newBalance;
+        if (account.getRole() == Role.MEMBER) {
+            Member member = memberRepository.findByAccount(account);
+            newBalance = member.addCache(amount);
+        } else if (account.getRole() == Role.PHOTOGRAPHER) {
+            Photographer photographer = photographerRepository.findByAccount(account);
+            newBalance = photographer.addCache(amount);
+        } else {
+            throw new AccessDeniedException("캐시 충전 권한이 없습니다.");
+        }
+
+        CashHistory history = cashHistoryRepository.save(
+                CashHistory.ofCharge(account, amount, newBalance));
+        return new CashChargeResponse(history.getId(), newBalance);
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/entity/UserBasicInfo.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/entity/UserBasicInfo.java
@@ -29,4 +29,9 @@ public class UserBasicInfo {
 
     @Column(name = "deleted_at")
     protected LocalDateTime deletedAt;
+
+    public int addCache(int amount) {
+        this.cache = (this.cache == null ? 0 : this.cache) + amount;
+        return this.cache;
+    }
 }

--- a/src/main/java/com/pickkasso/pickkasso/user/repository/PhotographerRepository.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/repository/PhotographerRepository.java
@@ -1,7 +1,9 @@
 package com.pickkasso.pickkasso.user.repository;
 
+import com.pickkasso.pickkasso.user.entity.Account;
 import com.pickkasso.pickkasso.user.entity.Photographer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PhotographerRepository extends JpaRepository<Photographer, Long> {
+    Photographer findByAccount(Account account);
 }

--- a/src/main/resources/templates/fragments/modal/cash-charge-modal.html
+++ b/src/main/resources/templates/fragments/modal/cash-charge-modal.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<th:block th:fragment="cashChargeModal">
+
+  <div id="cash-charge-modal"
+       style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.45); z-index:1000; align-items:center; justify-content:center;">
+    <div style="background:#fff; border-radius:12px; width:420px; padding:28px 28px 20px;">
+
+      <h2 style="font-size:18px; font-weight:600; margin:0 0 6px;">캐시 충전</h2>
+      <p style="font-size:12px; color:#888; margin:0 0 20px;">충전할 금액을 선택해 주세요.</p>
+
+      <div id="cash-preset-list" style="display:grid; grid-template-columns:1fr 1fr; gap:10px;">
+        <div class="cash-item" data-amount="10000" onclick="cashChargeModal.select(this)">
+          <span class="cash-label">10,000 C</span>
+        </div>
+        <div class="cash-item" data-amount="30000" onclick="cashChargeModal.select(this)">
+          <span class="cash-label">30,000 C</span>
+        </div>
+        <div class="cash-item" data-amount="50000" onclick="cashChargeModal.select(this)">
+          <span class="cash-label">50,000 C</span>
+        </div>
+        <div class="cash-item" data-amount="100000" onclick="cashChargeModal.select(this)">
+          <span class="cash-label">100,000 C</span>
+        </div>
+      </div>
+
+      <div style="border-top:1px solid #eee; margin-top:20px; padding-top:16px; display:flex; justify-content:flex-end; gap:8px;">
+        <button type="button" onclick="cashChargeModal.close()"
+                style="padding:8px 20px; border:1px solid #ddd; border-radius:8px; background:#fff; cursor:pointer;">취소</button>
+        <button type="button" id="btn-confirm-cash" onclick="cashChargeModal.confirm()"
+                style="padding:8px 20px; background:#1D3CFF; color:#fff; border:none; border-radius:8px; opacity:0.4; cursor:default;" disabled>
+          충전하기
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <style>
+    .cash-item {
+      display: flex; justify-content: center; align-items: center;
+      padding: 18px 16px; border-radius: 10px;
+      border: 1.5px solid #eee; cursor: pointer;
+      transition: border-color 0.15s, background 0.15s;
+    }
+    .cash-item:hover { border-color: #1D3CFF; }
+    .cash-item[data-selected="true"] { border-color: #1D3CFF; background: #EEF2FF; }
+    .cash-label { font-size: 14px; font-weight: 600; color: #1A1A1A; }
+  </style>
+
+  <script>
+    const cashChargeModal = {
+      amount: null,
+      onSuccess: null,
+
+      open(onSuccess) {
+        this.amount = null;
+        this.onSuccess = onSuccess || null;
+        document.querySelectorAll('.cash-item').forEach(el => el.dataset.selected = 'false');
+        this.setConfirmEnabled(false);
+        document.getElementById('cash-charge-modal').style.display = 'flex';
+      },
+
+      close() {
+        document.getElementById('cash-charge-modal').style.display = 'none';
+      },
+
+      select(el) {
+        document.querySelectorAll('.cash-item').forEach(x => x.dataset.selected = 'false');
+        el.dataset.selected = 'true';
+        this.amount = parseInt(el.dataset.amount, 10);
+        this.setConfirmEnabled(true);
+      },
+
+      setConfirmEnabled(enabled) {
+        const btn = document.getElementById('btn-confirm-cash');
+        btn.disabled = !enabled;
+        btn.style.opacity = enabled ? '1' : '0.4';
+        btn.style.cursor = enabled ? 'pointer' : 'default';
+      },
+
+      async confirm() {
+        if (!this.amount) return;
+        const csrfToken  = document.querySelector('meta[name="_csrf"]')?.content || '';
+        const csrfHeader = document.querySelector('meta[name="_csrf_header"]')?.content || 'X-CSRF-TOKEN';
+        try {
+          const res = await fetch('/api/v1/cash/charge', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', [csrfHeader]: csrfToken },
+            body: JSON.stringify({ amount: this.amount })
+          });
+          if (!res.ok) {
+            const err = await res.json().catch(() => ({ message: '충전에 실패했습니다.' }));
+            throw new Error(err.message || '충전에 실패했습니다.');
+          }
+          const data = await res.json();
+          if (typeof this.onSuccess === 'function') this.onSuccess(data);
+          this.close();
+          alert(this.amount.toLocaleString() + ' C 충전이 완료되었습니다.');
+        } catch (e) {
+          alert('충전 실패: ' + e.message);
+        }
+      }
+    };
+  </script>
+
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/mypage-sidebar.html
+++ b/src/main/resources/templates/fragments/mypage-sidebar.html
@@ -16,7 +16,7 @@
       <!-- 캐시 잔액 -->
       <div class="mt-3 w-full rounded-xl bg-[#F9FAFC] border border-[#CCC] px-4 py-2.5 flex items-center justify-between">
         <span class="text-xs text-[#888]">캐시 잔액</span>
-        <span class="text-sm font-bold text-[#1D3CFF]"
+        <span id="sidebarCashBalance" class="text-sm font-bold text-[#1D3CFF]"
               th:text="${member.cache != null ? #numbers.formatInteger(member.cache, 1, 'COMMA') + ' C' : '0 C'}">0 C</span>
       </div>
     </div>

--- a/src/main/resources/templates/layouts/default.html
+++ b/src/main/resources/templates/layouts/default.html
@@ -5,6 +5,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="_csrf"        th:content="${_csrf.token}"/>
+  <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
   <title th:replace="${title}">PICKKASSO</title>
 
   <!-- Global Base Styles (fonts, design tokens) — Tailwind보다 먼저 로드 -->

--- a/src/main/resources/templates/user/mypage/profile.html
+++ b/src/main/resources/templates/user/mypage/profile.html
@@ -62,10 +62,11 @@
           <div class="flex items-center justify-between gap-4 rounded-xl bg-[#F9FAFC] border border-[#CCC] px-5 py-4">
             <div>
               <p class="text-xs text-[#888] mb-1">보유 캐시</p>
-              <p class="text-2xl font-bold text-[#1D3CFF]"
+              <p id="cashBalance" class="text-2xl font-bold text-[#1D3CFF]"
                  th:text="${member.cache != null ? #numbers.formatInteger(member.cache, 1, 'COMMA') + ' C' : '0 C'}">0 C</p>
             </div>
-            <button class="bg-white border border-[#1D3CFF] text-[#1D3CFF] hover:bg-[#1D3CFF] hover:text-white font-semibold px-4 py-2 rounded-lg text-sm transition-colors">
+            <button class="bg-white border border-[#1D3CFF] text-[#1D3CFF] hover:bg-[#1D3CFF] hover:text-white font-semibold px-4 py-2 rounded-lg text-sm transition-colors"
+                    onclick="cashChargeModal.open(onCashChargeSuccess)">
               충전하기
             </button>
           </div>
@@ -99,6 +100,16 @@
       </div>
     </div>
   </div>
+  <th:block th:replace="~{fragments/modal/cash-charge-modal :: cashChargeModal}" />
+  <script>
+    function onCashChargeSuccess(data) {
+      const txt = data.newBalance.toLocaleString() + ' C';
+      const main = document.getElementById('cashBalance');
+      const side = document.getElementById('sidebarCashBalance');
+      if (main) main.textContent = txt;
+      if (side) side.textContent = txt;
+    }
+  </script>
 </main>
 
 </body>

--- a/src/main/resources/templates/user/reservation.html
+++ b/src/main/resources/templates/user/reservation.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="_csrf"        th:content="${_csrf.token}"/>
+  <meta name="_csrf_header" th:content="${_csrf.headerName}"/>
   <title>예약하기 | PICKKASSO</title>
   <link rel="stylesheet" th:href="@{/css/global.css}">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -294,12 +296,13 @@
           <div>
             <p class="text-xs text-[#888] mb-0.5">보유 캐시</p>
             <p class="text-xl font-bold text-[#1A1A1A]">
-              <span th:text="${member != null and member.cache != null ? #numbers.formatInteger(member.cache, 0, 'COMMA') : '0'}">0</span>
+              <span id="cashBalance" th:text="${member != null and member.cache != null ? #numbers.formatInteger(member.cache, 0, 'COMMA') : '0'}">0</span>
               <span class="text-[#1D3CFF]">C</span>
             </p>
           </div>
           <button type="button"
-                  class="text-sm font-semibold border border-[#1D3CFF] text-[#1D3CFF] px-4 py-2 rounded-lg hover:bg-[#1D3CFF] hover:text-white active:bg-[#1530E0] transition-colors">
+                  class="text-sm font-semibold border border-[#1D3CFF] text-[#1D3CFF] px-4 py-2 rounded-lg hover:bg-[#1D3CFF] hover:text-white active:bg-[#1530E0] transition-colors"
+                  onclick="cashChargeModal.open(onCashChargeSuccess)">
             + 캐시 충전
           </button>
         </div>
@@ -576,6 +579,22 @@
 
   renderTimeSlots();
 
+</script>
+
+<th:block th:replace="~{fragments/modal/cash-charge-modal :: cashChargeModal}" />
+<script>
+  function onCashChargeSuccess(data) {
+    const balanceEl = document.getElementById('cashBalance');
+    if (balanceEl) balanceEl.textContent = data.newBalance.toLocaleString();
+    const remainingEl = document.getElementById('remainingCash');
+    const totalPriceEl = document.getElementById('totalPrice');
+    if (remainingEl && totalPriceEl) {
+      const totalText = totalPriceEl.textContent.replace(/[^0-9]/g, '');
+      const total = parseInt(totalText, 10) || 0;
+      const remaining = Math.max(0, data.newBalance - total);
+      remainingEl.textContent = remaining.toLocaleString() + ' C';
+    }
+  }
 </script>
 
 </body>


### PR DESCRIPTION
## 작업 내용
- 마이페이지, 서비스 예약의 캐시충전 버튼을 눌렀을 때 충전하는 모달 기능

## 변경 사항
- user/cash/ 하위에 Controller, Service, Repository, Entity, DTO 생성
- UserBasicInfo.addcache() 메서드 추가해서 잔액 증가
- 모달 조회 프론트엔드 구현

## 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 관련 페이지 렌더링 확인

## 참고
- db t_member의 cache(오타) 컬럼 이용함.
- 실제 api 연동은 추후 진행하거나 연동하지 않는다면 모달 디자인만 수정해서 사용할 예정
- #45 