### PR TITLE
feat: 검색 페이지 기능 추가

### DIFF
--- a/src/main/java/com/pickkasso/pickkasso/item/controller/ItemController.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/controller/ItemController.java
@@ -30,7 +30,7 @@ public class ItemController {
 
         condition.setLat(dto.getLat());
         condition.setLng(dto.getLng());
-        condition.setDistance(5);
+        condition.setDistance(dto.getDistance());
         condition.setTag((dto.getTag() == null) ? null : tagService.findByName(dto.getTag()).orElse(null));
         condition.setDate(dto.getDate());
         condition.setOrderBy(dto.getOrderBy());

--- a/src/main/java/com/pickkasso/pickkasso/item/controller/ItemController.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/controller/ItemController.java
@@ -4,6 +4,7 @@ import com.pickkasso.pickkasso.global.tag.TagService;
 import com.pickkasso.pickkasso.item.dto.ItemBoxDto;
 import com.pickkasso.pickkasso.item.dto.ItemSearchCondition;
 import com.pickkasso.pickkasso.item.dto.ItemSearchFormDto;
+import com.pickkasso.pickkasso.item.entity.ItemType;
 import com.pickkasso.pickkasso.item.service.ItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -34,6 +35,16 @@ public class ItemController {
         condition.setDate(dto.getDate());
         condition.setOrderBy(dto.getOrderBy());
         condition.setPage((dto.getPage() == null) ? 1 : dto.getPage());
+
+        ItemType itemType = null;
+        if (dto.getItemType() != null) {
+            try {
+                itemType = ItemType.valueOf(dto.getItemType());
+            } catch (IllegalArgumentException e) {
+                itemType = null;
+            }
+        }
+        condition.setItemType(itemType);
 
         return condition;
     }

--- a/src/main/java/com/pickkasso/pickkasso/item/dto/ItemSearchCondition.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/dto/ItemSearchCondition.java
@@ -1,6 +1,7 @@
 package com.pickkasso.pickkasso.item.dto;
 
 import com.pickkasso.pickkasso.global.tag.Tag;
+import com.pickkasso.pickkasso.item.entity.ItemType;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,4 +17,5 @@ public class ItemSearchCondition {
     private LocalDate date;
     private String orderBy;
     private Integer page;
+    private ItemType itemType;
 }

--- a/src/main/java/com/pickkasso/pickkasso/item/dto/ItemSearchFormDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/dto/ItemSearchFormDto.java
@@ -18,4 +18,5 @@ public class ItemSearchFormDto {
     private String orderBy;
     private Integer page;
     private String itemType;
+    private Integer distance;
 }

--- a/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepositoryCustomImpl.java
@@ -44,7 +44,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
     // TODO: "공간 인덱스로 대상 row를 줄이고, 줄어든 row에만 ST_Distance_Sphere를 적용"이 더 효율적이라고 함
     private BooleanExpression withinDistance(Double lat, Double lng, Integer distance) {
         if (lat == null || lng == null || distance == null) return null;
-        return distanceExpression(lat, lng).loe(distance);
+        return distanceExpression(lat, lng).loe(distance * 1000);
     }
     private BooleanExpression withinDistance(NumberTemplate<Double> distanceExpr, Integer maxDistance) {
         if (distanceExpr == null || maxDistance == null) return null;
@@ -68,7 +68,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
             case "created-at-asc"   -> QItem.item.createdAt.asc();
             case "price-desc"       -> QItem.item.defaultPrice.desc();
             case "price-asc"        -> QItem.item.defaultPrice.asc();
-            case "distance"         -> distance.asc();
+            case "distance"         -> (distance == null) ? QItem.item.avgScore.desc() : distance.asc();
             default                 -> QItem.item.avgScore.desc();
         };
     }

--- a/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepositoryCustomImpl.java
@@ -5,6 +5,7 @@ import com.pickkasso.pickkasso.global.tag.QTagReference;
 import com.pickkasso.pickkasso.global.tag.Tag;
 import com.pickkasso.pickkasso.item.dto.ItemBoxDto;
 import com.pickkasso.pickkasso.item.dto.ItemSearchCondition;
+import com.pickkasso.pickkasso.item.entity.ItemType;
 import com.pickkasso.pickkasso.item.entity.QItem;
 import com.pickkasso.pickkasso.user.dto.photographer.QPhotographerSimpleCardDto;
 import com.querydsl.core.BooleanBuilder;
@@ -32,6 +33,10 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
 
     private BooleanExpression tagEq(Tag tag) {
         return (tag != null) ? QItem.item.tag.eq(tag) : null;
+    }
+
+    private BooleanExpression itemTypeEq(ItemType itemType) {
+        return (itemType != null) ? QItem.item.itemType.eq(itemType) : null;
     }
 
     private NumberExpression<Double> distanceExpression(Double lat, Double lng) {
@@ -73,6 +78,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
         };
     }
 
+    // 아직 날짜 관련 코드 구현 못함
     @Override
     public Page<ItemBoxDto> getSearchItemPage(ItemSearchCondition condition, int pageSize) {
         QItem item = QItem.item;
@@ -107,6 +113,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
             .join(item.photographer)
             .where(
                 tagEq(condition.getTag()),
+                itemTypeEq(condition.getItemType()),
                 // withinDistance(condition.getLat(), condition.getLng(), condition.getDistance())
                 withinDistance(distanceExpr, condition.getDistance())
             )
@@ -120,6 +127,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
             .join(item.tag)
             .where(
                 tagEq(condition.getTag()),
+                itemTypeEq(condition.getItemType()),
                 withinDistance(condition.getLat(), condition.getLng(), condition.getDistance())
             )
             .fetchOne();

--- a/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepositoryCustomImpl.java
@@ -49,7 +49,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
     // TODO: "공간 인덱스로 대상 row를 줄이고, 줄어든 row에만 ST_Distance_Sphere를 적용"이 더 효율적이라고 함
     private BooleanExpression withinDistance(Double lat, Double lng, Integer distance) {
         if (lat == null || lng == null || distance == null) return null;
-        return distanceExpression(lat, lng).loe(distance * 1000);
+        return distanceExpression(lat, lng).loe(distance);
     }
     private BooleanExpression withinDistance(NumberTemplate<Double> distanceExpr, Integer maxDistance) {
         if (distanceExpr == null || maxDistance == null) return null;

--- a/src/main/resources/templates/fragments/modal/location-modal.html
+++ b/src/main/resources/templates/fragments/modal/location-modal.html
@@ -11,10 +11,10 @@
 
       <!-- 탭 -->
       <div style="display:flex; border-bottom:1.5px solid #eee; margin-bottom:20px;">
-        <button id="tab-fav"    data-active="true"  type="button" onclick="locationModal.switchTab('fav')"
-                class="modal-tab">즐겨찾기</button>
-        <button id="tab-direct" data-active="false" type="button" onclick="locationModal.switchTab('direct')"
+        <button id="tab-direct" data-active="true"  type="button" onclick="locationModal.switchTab('direct')"
                 class="modal-tab">직접 선택</button>
+        <button id="tab-fav"    data-active="false" type="button" onclick="locationModal.switchTab('fav')"
+                class="modal-tab">즐겨찾기</button>
       </div>
 
       <!-- 본문 -->
@@ -27,8 +27,8 @@
         <div style="flex:1; position:relative; display:flex; flex-direction:column;">
 
           <!-- 즐겨찾기 패널 -->
-          <div id="panel-fav" style="flex:1; display:flex; flex-direction:column; overflow-y:auto; gap:8px;">
-            <div th:if="${favoriteList == null or #lists.isEmpty(favoriteList)}"
+          <div id="panel-fav"    style="flex:1; display:none;  flex-direction:column; overflow-y:auto; gap:8px;">
+          <div th:if="${favoriteList == null or #lists.isEmpty(favoriteList)}"
                  style="display:flex; align-items:center; justify-content:center; height:100%; color:#aaa; font-size:14px; text-align:center;">
               아직 저장된 즐겨찾기가 없습니다
             </div>
@@ -48,7 +48,7 @@
           </div>
 
           <!-- 직접 선택 패널 -->
-          <div id="panel-direct" style="flex:1; display:none; flex-direction:column; gap:12px;">
+          <div id="panel-direct" style="flex:1; display:flex; flex-direction:column; gap:12px;">
 
             <!-- 위치 정보 카드 -->
             <div style="flex:1; border:1px solid #eee; border-radius:12px; padding:16px; display:flex; flex-direction:column; justify-content:center;">
@@ -170,15 +170,14 @@
                       this.map = new kakao.maps.Map(container, options);
                       this.marker = new kakao.maps.Marker();
 
-                      // 클릭 핸들러 바인딩 (removeListener에서 동일 참조 필요)
                       this.mapClickHandler = (mouseEvent) => {
                           const lat = mouseEvent.latLng.getLat();
                           const lng = mouseEvent.latLng.getLng();
                           this.selectByClick(lat, lng);
                       };
 
-                      // 초기에는 즐겨찾기 탭이므로 클릭 비활성화
-                      // direct 탭 전환 시 addListener
+                      // ↓ 이 줄 추가: 초기 탭이 직접선택이므로 클릭 이벤트 바로 등록
+                      kakao.maps.event.addListener(this.map, 'click', this.mapClickHandler);
                   },
 
                   selectByClick(lat, lng) {

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -50,6 +50,9 @@
                     }
                 });
 
+                const itemType = document.getElementById('display-item-type');
+                itemType.disabled = !itemType.value;
+
                 this.submit();
             });
 
@@ -103,7 +106,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
             <path stroke-linecap="round" stroke-linejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
           </svg>
-          <span id="display-region" class="text-sm text-[#555] whitespace-nowrap"
+          <span id="display-region" class="text-sm flex-1 text-center text-[#555] whitespace-nowrap"
                 th:text="${param.region} ?: '지역선택'"></span>
           <button type="button"
                   id="clear-region-btn"
@@ -123,7 +126,7 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"/>
             <path stroke-linecap="round" stroke-linejoin="round" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"/>
           </svg>
-          <span id="display-category" class="text-sm text-[#555] whitespace-nowrap"
+          <span id="display-category" class="text-sm flex-1 text-center text-[#555] whitespace-nowrap"
                 th:text="${param.category} ?: '촬영유형'"></span>
         </div>
 
@@ -136,7 +139,7 @@
             <line x1="8" y1="2" x2="8" y2="6"/>
             <line x1="3" y1="10" x2="21" y2="10"/>
           </svg>
-          <span id="display-date" class="text-sm text-[#555] whitespace-nowrap"
+          <span id="display-date" class="text-sm flex-1 text-center text-[#555] whitespace-nowrap"
                 th:text="${param.date} ?: '날짜'"></span>
         </div>
         <!-- 촬영 방식 -->
@@ -144,12 +147,15 @@
           <svg class="text-[#0097FF] shrink-0" width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-2 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
           </svg>
-          <select id="display-item-type" name="itemType"
-                  class="text-sm text-[#555] bg-transparent border-0 outline-none cursor-pointer w-full">
-            <option value="" th:selected="${param.itemType == null}">촬영방식</option>
-            <option value="IN" th:selected="${param.itemType == 'IN'}">스튜디오</option>
-            <option value="OUT" th:selected="${param.itemType == 'OUT'}">출장촬영</option>
-          </select>
+          <div class="flex flex-1">
+            <select id="display-item-type"
+                    th:field="*{itemType}"
+                    class="appearance-none text-sm flex-1 text-center text-[#555] bg-transparent border-0 outline-none cursor-pointer">
+              <option value="">촬영방식</option>
+              <option value="IN">스튜디오</option>
+              <option value="OUT">출장촬영</option>
+            </select>
+          </div>
         </div>
         <!-- 검색 버튼 -->
         <button type="submit"

--- a/src/main/resources/templates/search/itemSearchForm.html
+++ b/src/main/resources/templates/search/itemSearchForm.html
@@ -64,8 +64,9 @@
                   document.getElementById("h-page").value = '';
                   const inputs = this.querySelectorAll('input[type="hidden"]');
                   inputs.forEach(input => {
+                      input.disabled = false; // 먼저 전부 활성화
                       if (!input.value) {
-                          input.disabled = true; // disabled된 input은 전송 안됨
+                          input.disabled = true;
                       }
                   });
 
@@ -86,6 +87,22 @@
                       window.location.href = url.toString();
                   });
               });
+
+              const hRegion = document.getElementById('h-region');
+              let _value = hRegion.value;
+
+              Object.defineProperty(hRegion, 'value', {
+                  get() { return _value; },
+                  set(v) {
+                      _value = v;
+                      hRegion.setAttribute('value', v); // ← 이거 추가
+                      syncDistanceOption();
+                  },
+                  configurable: true,
+              });
+
+              // 페이지 로딩 시 1회 실행
+              syncDistanceOption();
           });
 
           function resetUrl(url) {
@@ -97,11 +114,12 @@
                   date: document.getElementById("h-date").value,
               };
 
-              // 기존 파라미터 초기화
               url.search = "";
 
               Object.entries(params).forEach(([key, value]) => {
-                  if (value !== "" && value !== "null") url.searchParams.set(key, value);
+                  if (value !== "" && value !== "null") {
+                      url.searchParams.set(key, value); // 값 있는 것만 추가
+                  }
               });
 
               return url;
@@ -121,8 +139,35 @@
               url.searchParams.set("page", page);
               window.location.href = url.toString();
           }
+          function clearRegion() {
+              event.stopPropagation(); // ← 부모로 이벤트 전파 차단
+              document.getElementById("h-region").value = "";
+              document.getElementById("h-lat").value = "";
+              document.getElementById("h-lng").value = "";
+              document.getElementById("display-region").textContent = "지역선택";
+              document.getElementById('clear-region-btn').classList.add('hidden');
+          }
+
+          function syncDistanceOption() {
+              const region = document.getElementById('h-region').value;
+              const select = document.querySelector('.sort-select');
+              const existing = select.querySelector('option[value="distance"]');
+
+              if (region && !existing) {
+                  const opt = document.createElement('option');
+                  opt.value = 'distance';
+                  opt.textContent = '가까운 순';
+                  select.appendChild(opt);
+              } else if (!region && existing) {
+                  existing.remove();
+              }
+          }
       </script>
     </th:block>
+    <style>
+        #h-region {
+        }
+    </style>
   </head>
   <body>
     <main th:fragment="main">
@@ -176,10 +221,10 @@
             <!-- address는 아래 text input으로 대신 제출 -->
 
             <!-- 지역선택 버튼 (표시용) -->
-            <button
+            <div
               type="button"
               onclick="locationModal.open()"
-              class="flex items-center gap-1.5 px-[18px] h-full bg-transparent border-0 border-r border-[#E8E8E8] text-sm font-medium text-[#444] hover:text-[#1D3CFF] transition-colors whitespace-nowrap cursor-pointer"
+              class="flex items-center gap-1.5 px-[18px] h-full min-w-[200px] bg-transparent border-0 border-r border-[#E8E8E8] text-sm font-medium text-[#444] hover:text-[#1D3CFF] transition-colors whitespace-nowrap cursor-pointer"
             >
               <svg
                 class="text-[#0097FF] shrink-0"
@@ -200,18 +245,17 @@
                 th:text="${itemSearchFormDto.address != null and !#strings.isEmpty(itemSearchFormDto.address) ? itemSearchFormDto.address : '지역선택'}"
                 >지역선택</span
               >
-              <svg
-                class="text-[#AAA] shrink-0"
-                width="11"
-                height="11"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2.5"
-              >
-                <path d="M6 9l6 6 6-6" />
-              </svg>
-            </button>
+              <button type="button"
+                      id="clear-region-btn"
+                      onclick="clearRegion(event)"
+                      th:classappend="${itemSearchFormDto.address != null and !itemSearchFormDto.address.isEmpty()} ? '' : 'hidden'"
+                      class="text-[#AAA] hover:text-[#FF3B3B] transition-colors bg-transparent border-0 cursor-pointer shrink-0 p-0">
+                <svg width="14" height="14" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+                  <line x1="18" y1="6" x2="6" y2="18"/>
+                  <line x1="6" y1="6" x2="18" y2="18"/>
+                </svg>
+              </button>
+            </div>
 
             <!-- 촬영유형 버튼 (표시용) -->
             <button
@@ -361,14 +405,14 @@
                 인기순
               </option>
               <option
-                  value="created-at-cesc"
-                  th:selected="${itemSearchFormDto.orderBy == 'created-at-desc'}"
+                value="created-at-desc"
+                th:selected="${itemSearchFormDto.orderBy == 'created-at-desc'}"
               >
                 최신순
               </option>
               <option
-                  value="created-at-asc"
-                  th:selected="${itemSearchFormDto.orderBy == 'created-at-asc'}"
+                value="created-at-asc"
+                th:selected="${itemSearchFormDto.orderBy == 'created-at-asc'}"
               >
                 오래된 순
               </option>
@@ -379,14 +423,15 @@
                 낮은 가격순
               </option>
               <option
-                  value="price-desc"
-                  th:selected="${itemSearchFormDto.orderBy == 'price-desc'}"
+                value="price-desc"
+                th:selected="${itemSearchFormDto.orderBy == 'price-desc'}"
               >
                 높은 가격순
               </option>
               <option
-                  value="distance"
-                  th:selected="${itemSearchFormDto.orderBy == 'distance'}"
+                th:if="${itemSearchFormDto.address != null and !itemSearchFormDto.address.isEmpty()}"
+                value="distance"
+                th:selected="${itemSearchFormDto.orderBy == 'distance'}"
               >
                 가까운 순
               </option>

--- a/src/main/resources/templates/search/itemSearchForm.html
+++ b/src/main/resources/templates/search/itemSearchForm.html
@@ -116,6 +116,7 @@
                   tag: document.getElementById("h-category").value,
                   date: document.getElementById("h-date").value,
                   itemType: document.getElementById("display-item-type").value,
+                  distance: document.getElementById("h-distance")?.value,  // ← 추가
               };
 
               url.search = "";
@@ -125,6 +126,11 @@
                       url.searchParams.set(key, value); // 값 있는 것만 추가
                   }
               });
+
+              // region 없으면 distance도 제거
+              if (!params.address) {
+                  url.searchParams.delete("distance");
+              }
 
               return url;
           }
@@ -150,12 +156,21 @@
               document.getElementById("h-lng").value = "";
               document.getElementById("display-region").textContent = "지역선택";
               document.getElementById('clear-region-btn').classList.add('hidden');
+
+              // distance도 초기화
+              const hDistance = document.getElementById("h-distance");
+              if (hDistance) hDistance.value = "";
+
+              // 거리필터 select도 초기화
+              const distanceFilter = document.getElementById('distance-filter-select');
+              if (distanceFilter) distanceFilter.value = "";
           }
 
           function syncDistanceOption() {
               const region = document.getElementById('h-region').value;
-              const select = document.querySelector('.sort-select');
+              const select = document.querySelector('#order-by-select');
               const existing = select.querySelector('option[value="distance"]');
+              const distanceFilter = document.getElementById('distance-filter-select');
 
               if (region && !existing) {
                   const opt = document.createElement('option');
@@ -165,6 +180,20 @@
               } else if (!region && existing) {
                   existing.remove();
               }
+
+              // 거리 필터 show/hide
+              if (distanceFilter) {
+                  distanceFilter.classList.toggle('hidden', !region);
+              }
+          }
+
+          function changeDistance(value) {
+              const url = resetUrl(new URL(window.location.href));
+              url.searchParams.set("page", '');
+              if (value) {
+                  url.searchParams.set("distance", value);
+              }
+              window.location.href = url.toString();
           }
       </script>
     </th:block>
@@ -222,6 +251,8 @@
               th:value="${itemSearchFormDto.orderBy}"
             />
             <input type="hidden" name="page" id="h-page" th:value="${itemSearchFormDto.page}" />
+            <input type="hidden" id="h-distance" name="distance" th:value="${itemSearchFormDto.distance}"/>
+
             <!-- address는 아래 text input으로 대신 제출 -->
 
             <!-- 지역선택 버튼 (표시용) -->
@@ -378,6 +409,7 @@
               >개의 서비스
             </span>
             <select
+              id="order-by-select"
               class="sort-select text-sm text-[#444] border border-[#CCC] rounded-lg py-[7px] pl-3 pr-7 bg-white cursor-pointer outline-none"
               onchange="changeSortOrder(this.value)"
             >
@@ -424,6 +456,24 @@
               >
                 가까운 순
               </option>
+            </select>
+          </div>
+          <div class="flex items-center gap-3 shrink-0">
+
+            <!-- 거리 필터 (address 있을 때만 표시) -->
+            <select
+              id="distance-filter-select"
+              th:classappend="${itemSearchFormDto.address == null or itemSearchFormDto.address.isEmpty()} ? 'hidden' : ''"
+              class="sort-select text-sm text-[#444] border border-[#CCC] rounded-lg py-[7px] pl-3 pr-7 bg-white cursor-pointer outline-none"
+              onchange="changeDistance(this.value)"
+            >
+              <option value="" th:selected="${itemSearchFormDto.distance != null}">거리 제한 없음</option>
+              <option value="1"  th:selected="${itemSearchFormDto.distance != null and itemSearchFormDto.distance == 1}">1km 이내</option>
+              <option value="3"  th:selected="${itemSearchFormDto.distance != null and itemSearchFormDto.distance == 3}">3km 이내</option>
+              <option value="5"  th:selected="${itemSearchFormDto.distance != null and itemSearchFormDto.distance == 5}">5km 이내</option>
+              <option value="10" th:selected="${itemSearchFormDto.distance != null and itemSearchFormDto.distance == 10}">10km 이내</option>
+              <option value="20" th:selected="${itemSearchFormDto.distance != null and itemSearchFormDto.distance == 20}">20km 이내</option>
+              <option value="50" th:selected="${itemSearchFormDto.distance != null and itemSearchFormDto.distance == 50}">50km 이내</option>
             </select>
           </div>
         </div>

--- a/src/main/resources/templates/search/itemSearchForm.html
+++ b/src/main/resources/templates/search/itemSearchForm.html
@@ -70,6 +70,9 @@
                       }
                   });
 
+                  const itemType = document.getElementById('display-item-type');
+                  itemType.disabled = !itemType.value;
+
                   this.submit();
               });
 
@@ -112,6 +115,7 @@
                   lng: document.getElementById("h-lng").value,
                   tag: document.getElementById("h-category").value,
                   date: document.getElementById("h-date").value,
+                  itemType: document.getElementById("display-item-type").value,
               };
 
               url.search = "";
@@ -224,7 +228,7 @@
             <div
               type="button"
               onclick="locationModal.open()"
-              class="flex items-center gap-1.5 px-[18px] h-full min-w-[200px] bg-transparent border-0 border-r border-[#E8E8E8] text-sm font-medium text-[#444] hover:text-[#1D3CFF] transition-colors whitespace-nowrap cursor-pointer"
+              class="flex items-center gap-1.5 px-[18px] h-full flex-1 bg-transparent border-0 border-r border-[#E8E8E8] text-sm font-medium text-[#444] hover:text-[#1D3CFF] transition-colors whitespace-nowrap cursor-pointer"
             >
               <svg
                 class="text-[#0097FF] shrink-0"
@@ -241,7 +245,8 @@
                 <circle cx="12" cy="9" r="2.5" />
               </svg>
               <span
-                  id="display-region"
+                id="display-region"
+                class="flex-1 text-center"
                 th:text="${itemSearchFormDto.address != null and !#strings.isEmpty(itemSearchFormDto.address) ? itemSearchFormDto.address : '지역선택'}"
                 >지역선택</span
               >
@@ -257,11 +262,11 @@
               </button>
             </div>
 
-            <!-- 촬영유형 버튼 (표시용) -->
-            <button
+            <!-- 촬영유형 버튼 -->
+            <div
               type="button"
               onclick="categoryModal.open()"
-              class="flex items-center gap-1.5 px-[18px] h-full bg-transparent border-0 border-r border-[#E8E8E8] text-sm font-medium text-[#444] hover:text-[#1D3CFF] transition-colors whitespace-nowrap cursor-pointer"
+              class="flex items-center gap-1.5 px-[18px] h-full flex-1 bg-transparent border-0 border-r border-[#E8E8E8] text-sm font-medium text-[#444] hover:text-[#1D3CFF] transition-colors whitespace-nowrap cursor-pointer"
             >
               <svg
                 class="text-[#0097FF] shrink-0"
@@ -278,27 +283,17 @@
               </svg>
               <span
                 id="display-category"
+                class="flex-1 text-center"
                 th:text="${itemSearchFormDto.tag != null and !#strings.isEmpty(itemSearchFormDto.tag) ? itemSearchFormDto.tag : '촬영유형'}"
                 >촬영유형</span
               >
-              <svg
-                class="text-[#AAA] shrink-0"
-                width="11"
-                height="11"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2.5"
-              >
-                <path d="M6 9l6 6 6-6" />
-              </svg>
-            </button>
+            </div>
 
-            <!-- 날짜 버튼 (표시용) -->
-            <button
+            <!-- 날짜 버튼 -->
+            <div
               type="button"
               onclick="dateModal.open()"
-              class="flex items-center gap-1.5 px-[18px] h-full bg-transparent border-0 border-r border-[#E8E8E8] text-sm font-medium text-[#444] hover:text-[#1D3CFF] transition-colors whitespace-nowrap cursor-pointer"
+              class="flex items-center gap-1.5 px-[18px] h-full flex-1 bg-transparent border-0 border-r border-[#E8E8E8] text-sm font-medium text-[#444] hover:text-[#1D3CFF] transition-colors whitespace-nowrap cursor-pointer"
             >
               <svg
                 class="text-[#0097FF] shrink-0"
@@ -316,31 +311,25 @@
               </svg>
               <span
                 id="display-date"
+                class="flex-1 text-center"
                 th:text="${itemSearchFormDto.date != null ? #temporals.format(itemSearchFormDto.date, 'MM/dd') : '날짜'}"
                 >날짜</span
               >
-              <svg
-                class="text-[#AAA] shrink-0"
-                width="11"
-                height="11"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2.5"
-              >
-                <path d="M6 9l6 6 6-6" />
+            </div>
+            <!-- 촬영 방식 -->
+            <div class="flex items-center gap-2 px-[18px] h-full flex-1 border-r border-[#E8E8E8]">
+              <svg class="text-[#0097FF] shrink-0" width="16" height="16" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-2 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"/>
               </svg>
-            </button>
-
-<!--            &lt;!&ndash; address 실제 제출 input (화면에서 숨김, sr-only 사용 불가하므로 opacity-0 width-0) &ndash;&gt;-->
-<!--            <input-->
-<!--              type="text"-->
-<!--              name="address"-->
-<!--              th:value="${itemSearchFormDto.address}"-->
-<!--              class="w-0 h-0 p-0 border-0 opacity-0 absolute"-->
-<!--              aria-hidden="true"-->
-<!--            />-->
-
+              <div class="flex flex-1">
+                <select id="display-item-type" name="itemType"
+                        class="appearance-none text-sm flex-1 text-center bg-transparent border-0 outline-none cursor-pointer">
+                  <option value="" th:selected="${itemSearchFormDto.itemType == null}">촬영방식</option>
+                  <option value="IN" th:selected="${itemSearchFormDto.itemType == 'IN'}">스튜디오</option>
+                  <option value="OUT" th:selected="${itemSearchFormDto.itemType == 'OUT'}">출장촬영</option>
+                </select>
+              </div>
+            </div>
             <!-- 검색 버튼 -->
             <button
                 type="submit"


### PR DESCRIPTION
## 작업 내용
- lat, lng 비었을 때, 가까운 순 정렬을 막음
- address가 비었을 때, 가까운 순 정렬 등장하지 않게 수정
- 지도 modal 창 닫히지 않는 오류 수정
- 지도 modal의 옵션의 순서 변경
- itemType: 스튜디오 | 외부촬영 여부를 검색조건에 반영
- distance: 거리에 따른 필터링 추가
- 검색바 디자인 수정

## 변경 사항
- ItemSearchFormDto에 distance 추가

## 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 관련 페이지 렌더링 확인