### PR TITLE
Feature/mypage password 2

### DIFF
--- a/src/main/java/com/pickkasso/pickkasso/global/advice/GlobalModelAttributes.java
+++ b/src/main/java/com/pickkasso/pickkasso/global/advice/GlobalModelAttributes.java
@@ -1,0 +1,53 @@
+package com.pickkasso.pickkasso.global.advice;
+
+import com.pickkasso.pickkasso.user.entity.Account;
+import com.pickkasso.pickkasso.user.entity.Member;
+import com.pickkasso.pickkasso.user.repository.AccountRepository;
+import com.pickkasso.pickkasso.user.repository.MemberRepository;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.ui.Model;
+
+/**
+ * 모든 뷰에서 공통적으로 사용할 사용자 Role과 ID를 모델에 자동으로 추가
+ * Header fragment에서 Role별 링크와 텍스트를 분기할 때 사용
+ */
+@ControllerAdvice
+public class GlobalModelAttributes {
+
+    private final AccountRepository accountRepository;
+    private final MemberRepository memberRepository;
+
+    // 생성자 주입
+    public GlobalModelAttributes(AccountRepository accountRepository, MemberRepository memberRepository) {
+        this.accountRepository = accountRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    /**
+     * 모든 컨트롤러의 뷰 렌더링 전에 호출
+     * 로그인한 사용자라면 Role과 ID를 Model에 담아 헤더 등에서 활용 가능
+     */
+    @ModelAttribute
+    public void addUserRoleAndId(Authentication auth, Model model) {
+        // 사용자가 로그인 상태인지 확인
+        if(auth != null && auth.isAuthenticated()) {
+            // 로그인한 계정 정보 조회
+            Account account = accountRepository.findByUsername(auth.getName());
+            // 계정과 연결된 멤버 정보 조회
+            Member member = memberRepository.findByAccount(account);
+
+            // 모델에 Role과 userId 추가
+            // - role: HEADER에서 회원/작가 분기용
+            // - userId: 작가 대시보드 링크 생성 시 사용
+
+            // Role 확인 로그
+            System.out.println("Authentication Authorities:");
+            auth.getAuthorities().forEach(a -> System.out.println(a.getAuthority()));
+
+            model.addAttribute("role", account.getRole().name());
+            model.addAttribute("userId", member.getId());
+        }
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/global/controller/HomeController.java
+++ b/src/main/java/com/pickkasso/pickkasso/global/controller/HomeController.java
@@ -5,6 +5,7 @@ import com.pickkasso.pickkasso.global.tag.TagService;
 import com.pickkasso.pickkasso.item.dto.ItemSearchFormDto;
 import com.pickkasso.pickkasso.item.service.ItemService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/pickkasso/pickkasso/user/auth/SecurityConfig.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/auth/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.thymeleaf.extras.springsecurity6.dialect.SpringSecurityDialect;
 
 @Configuration
 @EnableWebSecurity
@@ -35,8 +36,8 @@ public class SecurityConfig {
                 .oauth2Login(oauth -> oauth
                         .loginPage("/login")
                         .userInfoEndpoint(user -> user
-                                .userService(customOAuth2UserService)
-                        )
+                                .userService(customOAuth2UserService))
+                                .successHandler(customSuccessHandler)
                         .defaultSuccessUrl("/", true)
                 )
                .logout(logout -> logout

--- a/src/main/java/com/pickkasso/pickkasso/user/controller/MyPageController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/MyPageController.java
@@ -1,15 +1,18 @@
 package com.pickkasso.pickkasso.user.controller;
 
+import com.pickkasso.pickkasso.user.dto.PasswordChangeDto;
 import com.pickkasso.pickkasso.user.entity.Account;
 import com.pickkasso.pickkasso.user.entity.Member;
 import com.pickkasso.pickkasso.user.repository.AccountRepository;
 import com.pickkasso.pickkasso.user.repository.MemberRepository;
+import com.pickkasso.pickkasso.user.service.AccountService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequiredArgsConstructor
@@ -18,6 +21,7 @@ public class MyPageController {
 
     private final MemberRepository memberRepository;
     private final AccountRepository accountRepository;
+    private final PasswordEncoder passwordEncoder;
 
     private Member getCurrentMember(Authentication auth) {
         Account account = accountRepository.findByUsername(auth.getName());
@@ -42,4 +46,37 @@ public class MyPageController {
         model.addAttribute("activeTab", "profile");
         return "user/mypage/profile";
     }
+
+    @PostMapping("/password")
+    public String changePassword(@ModelAttribute PasswordChangeDto dto,
+                                 Authentication auth,
+                                 RedirectAttributes redirectAttributes) {
+
+        Account account = accountRepository.findByUsername(auth.getName());
+
+        // 1. 현재 비밀번호 불일치
+        if(!passwordEncoder.matches(dto.getCurrentPassword(), account.getPassword())) {
+            redirectAttributes.addFlashAttribute("error", "current");
+            return "redirect:/member/mypage/profile";
+        }
+
+        // 2. 새 비밀번호 불일치
+        if(!dto.getNewPassword().equals(dto.getNewPasswordConfirm())) {
+            redirectAttributes.addFlashAttribute("error", "mismatch");
+            return "redirect:/member/mypage/profile";
+        }
+
+        // 3. 성공 시
+        account.changePassword(passwordEncoder.encode(dto.getNewPassword()));
+        accountRepository.save(account);
+
+        redirectAttributes.addFlashAttribute("success", true);
+        return "redirect:/member/mypage/profile";
+    }
+
+    @GetMapping("/member/mypage/profile")
+    public String getProfile() {
+        return "user/mypage/profile"; // flash attribute가 model에 자동으로 담김
+    }
+
 }

--- a/src/main/java/com/pickkasso/pickkasso/user/controller/MyPageController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/MyPageController.java
@@ -75,8 +75,16 @@ public class MyPageController {
     }
 
     @GetMapping("/member/mypage/profile")
-    public String getProfile() {
+    public String getProfile(Authentication auth, Model model) {
         return "user/mypage/profile"; // flash attribute가 model에 자동으로 담김
+    }
+
+    @GetMapping("/photographer/{photographerId}/profile")
+    public String photographerProfile(@PathVariable Long photographerId, Model model) {
+        // photographerId로 작가 정보 조회
+        Member photographer = memberRepository.findById(photographerId).orElseThrow();
+        model.addAttribute("photographer", photographer);
+        return "photographer/profile"; // 작가 대시보드 뷰
     }
 
 }

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/AccountDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/AccountDto.java
@@ -5,6 +5,8 @@ import com.pickkasso.pickkasso.user.entity.Role;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.transaction.annotation.Transactional;
 
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/PasswordChangeDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/PasswordChangeDto.java
@@ -1,0 +1,12 @@
+package com.pickkasso.pickkasso.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PasswordChangeDto {
+    private String currentPassword;
+    private String newPassword;
+    private String newPasswordConfirm;
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/service/AccountService.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/service/AccountService.java
@@ -1,11 +1,13 @@
 package com.pickkasso.pickkasso.user.service;
 
 import com.pickkasso.pickkasso.user.dto.AccountDto;
+import com.pickkasso.pickkasso.user.dto.PasswordChangeDto;
 import com.pickkasso.pickkasso.user.entity.Account;
 import com.pickkasso.pickkasso.user.entity.Member;
 import com.pickkasso.pickkasso.user.repository.AccountRepository;
 import com.pickkasso.pickkasso.user.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -68,8 +70,9 @@ public class AccountService {
         // 4. 암호화
         String encodedPw = passwordEncoder.encode(tempPw);
 
-        // 5. 비밀번호 변경
+        // 5. 비밀번호 변경 저장
         account.changePassword(encodedPw);
+        accountRepository.save(account);
 
         return tempPw;
     }

--- a/src/main/java/com/pickkasso/pickkasso/user/service/SignupService.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/service/SignupService.java
@@ -40,30 +40,30 @@ public class SignupService {
                 )
         );
 
-
-        //  Member 생성
-        Member member = Member.createMember(
+        if (dto.getRole() == Role.MEMBER) {
+            //  Member 생성
+            Member member = Member.createMember(
                 account,
                 dto.getEmail(),
                 dto.getName(),
                 dto.getGender(),
                 dto.getPhone(),
                 0
-        );
+            );
 
-        memberRepository.save(member);
-
-        if (dto.getRole() == Role.PHOTOGRAPHER) {
+            memberRepository.save(member);
+        } else if (dto.getRole() == Role.PHOTOGRAPHER) {
             Photographer photographer = Photographer.createMember(
-                    account,
-                    dto.getEmail(),
-                    dto.getName(),
-                    dto.getGender(),
-                    dto.getPhone(),
-                    0
+                account,
+                dto.getEmail(),
+                dto.getName(),
+                dto.getGender(),
+                dto.getPhone(),
+                0
             );
             photographerRepository.save(photographer);
+        } else if (dto.getRole() == Role.ADMIN) {
+            // pass
         }
-
     }
 }

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -28,15 +28,15 @@
     <div class="flex items-center gap-3">
 
       <!-- 비로그인 -->
-      <sec:authorize access="isAnonymous()">
+      <th:block th:if="${#authorization.expression('isAnonymous()')}">
         <a th:href="@{/login}"
            class="text-sm font-semibold bg-white border border-[#1D3CFF] text-[#1D3CFF] hover:bg-[#1D3CFF] hover:text-white active:bg-[#1530E0] active:border-[#1530E0] px-5 py-2 rounded-lg transition-colors no-underline">
           로그인
         </a>
-      </sec:authorize>
+      </th:block>
 
       <!-- 로그인 상태 -->
-      <sec:authorize access="isAuthenticated()">
+      <th:block th:if="${#authorization.expression('isAuthenticated()')}">
         <a th:href="@{/member/mypage}"
            class="text-[15px] font-medium text-[#444] hover:text-[#1D3CFF] transition-colors no-underline">
           마이페이지
@@ -47,7 +47,7 @@
             로그아웃
           </button>
         </form>
-      </sec:authorize>
+      </th:block>
 
     </div>
   </div>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -37,9 +37,9 @@
 
       <!-- 로그인 상태 -->
       <th:block th:if="${#authorization.expression('isAuthenticated()')}">
-        <a th:href="@{/member/mypage}"
+        <a th:href="${role == 'PHOTOGRAPHER' ? '/photographer/' + userId + '/profile' : '/member/mypage'}"
+           th:text="${role == 'PHOTOGRAPHER' ? '작가 대시보드' : '마이페이지'}"
            class="text-[15px] font-medium text-[#444] hover:text-[#1D3CFF] transition-colors no-underline">
-          마이페이지
         </a>
         <form th:action="@{/logout}" method="post" class="inline m-0">
           <button type="submit"

--- a/src/main/resources/templates/user/mypage/profile.html
+++ b/src/main/resources/templates/user/mypage/profile.html
@@ -72,29 +72,39 @@
         </div>
 
         <!-- 비밀번호 변경 카드 -->
+        <form th:action="@{/member/mypage/password}" method="post">
         <div class="bg-white border border-[#CCC] rounded-2xl p-6">
           <h2 class="text-base font-semibold text-[#1A1A1A] mb-5">비밀번호 변경</h2>
           <div class="space-y-3 max-w-md">
             <div>
               <label class="block text-xs font-semibold text-[#888] uppercase tracking-wider mb-1.5">현재 비밀번호</label>
-              <input type="password" placeholder="현재 비밀번호"
+              <input type="password" placeholder="현재 비밀번호" name="currentPassword"
                      class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-4 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] focus:outline-none focus:border-[#0097FF] focus:ring-1 focus:ring-[#0097FF]">
+            </div>
+            <div th:if="${error == 'current'}" class="text-red-500 text-sm">
+              현재 비밀번호가 틀렸습니다.
             </div>
             <div>
               <label class="block text-xs font-semibold text-[#888] uppercase tracking-wider mb-1.5">새 비밀번호</label>
-              <input type="password" placeholder="새 비밀번호 (8자 이상)"
+              <input type="password" placeholder="새 비밀번호 (8자 이상)" name="newPassword"
                      class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-4 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] focus:outline-none focus:border-[#0097FF] focus:ring-1 focus:ring-[#0097FF]">
             </div>
-            <div>
               <label class="block text-xs font-semibold text-[#888] uppercase tracking-wider mb-1.5">새 비밀번호 확인</label>
-              <input type="password" placeholder="새 비밀번호 재입력"
+              <input type="password" placeholder="새 비밀번호 재입력" name="newPasswordConfirm"
                      class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-4 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] focus:outline-none focus:border-[#0097FF] focus:ring-1 focus:ring-[#0097FF]">
             </div>
-            <button class="bg-white border border-[#1D3CFF] text-[#1D3CFF] hover:bg-[#1D3CFF] hover:text-white font-semibold px-5 py-2.5 rounded-lg text-sm transition-colors mt-1">
+          <div th:if="${error == 'mismatch'}" class="text-red-500 text-sm">
+            새 비밀번호가 일치하지 않습니다.
+          </div>
+          <div th:if="${success != null}" class="text-green-500">
+            비밀번호가 변경되었습니다.</div>
+          <div>
+            <button class="bg-white border border-[#1D3CFF] text-[#1D3CFF] hover:bg-[#1D3CFF] hover:text-white font-semibold px-5 py-2.5 rounded-lg text-sm transition-colors mt-4">
               변경하기
             </button>
           </div>
         </div>
+        </form>
 
       </div>
     </div>


### PR DESCRIPTION
## 작업 내용 
- 헤더 로그인 상태에 따라 회원/작가 구분 링크와 텍스트 분기 처리 
- GlobalModelAttributes에서 role Enum → String 변환하여 Thymeleaf 조건문에서 정상 비교 가능하도록 수정 

## 변경 사항
 GlobalModelAttributes.java
 - 모든 페이지에서 로그인한 사용자의 역할 정보를 자동으로 모델에 넣어, 헤더에서 분기만 하면 바로 사용할 수 있도록 하기 위함
 
 header.html 
  로그인 상태일 때 role에 따라 
 - PHOTOGRAPHER: '작가 대시보드', /photographer/{userId}/profile 
 - MEMBER: '마이페이지', /member/mypage - 기존에는 Enum 객체 비교로 인해 항상 '마이페이지'만 표시되던 문제 수정 
 
 **※** 
  작가 대시보드는 일단 작가 프로필로 연결해놓았으며, 링크 변경 시
  header.html 40번째 줄과 MyPageController.java GetMapping 주소 수정 필요
 
  ## 테스트 
  - [x] 작가 계정 로그인 시 '작가 대시보드' 링크 확인 
  - [x] 회원 계정 로그인 시 '마이페이지' 링크 확인 
  - [x] 클릭 시 각 페이지 정상 이동 확인 
  
 ## 참고 
#48