### PR TITLE
feat: 대시보드 기능 개발

### DIFF
--- a/src/main/java/com/pickkasso/pickkasso/PickkassoApplication.java
+++ b/src/main/java/com/pickkasso/pickkasso/PickkassoApplication.java
@@ -2,8 +2,10 @@ package com.pickkasso.pickkasso;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PickkassoApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/pickkasso/pickkasso/global/config/ReservationDevSeeder.java
+++ b/src/main/java/com/pickkasso/pickkasso/global/config/ReservationDevSeeder.java
@@ -1,0 +1,226 @@
+package com.pickkasso.pickkasso.global.config;
+
+import com.pickkasso.pickkasso.global.tag.Tag;
+import com.pickkasso.pickkasso.global.tag.TagRepository;
+import com.pickkasso.pickkasso.item.entity.Item;
+import com.pickkasso.pickkasso.item.entity.ItemType;
+import com.pickkasso.pickkasso.item.entity.Plan;
+import com.pickkasso.pickkasso.item.repository.ItemRepository;
+import com.pickkasso.pickkasso.user.entity.*;
+import com.pickkasso.pickkasso.user.repository.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@Profile("dev")
+@RequiredArgsConstructor
+@Slf4j
+public class ReservationDevSeeder implements ApplicationRunner {
+
+    private final AccountRepository accountRepository;
+    private final MemberRepository memberRepository;
+    private final PhotographerRepository photographerRepository;
+    private final ItemRepository itemRepository;
+    private final TagRepository tagRepository;
+    private final ReservationRepository reservationRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        Photographer photographer = ensurePhotographer();
+        if (reservationRepository.countByPhotographerId(photographer.getId()) > 0) {
+            log.info("[seed] reservations already exist for dev photographer={} — skip", photographer.getId());
+            return;
+        }
+
+        Member m1 = ensureMember("dev_member1", "이수빈", "subin@test.com");
+        Member m2 = ensureMember("dev_member2", "정우진", "woojin@test.com");
+        Member m3 = ensureMember("dev_member3", "강지우", "jiwoo@test.com");
+
+        Map<String, Item> itemsByName = ensureItems(photographer);
+
+        LocalDate today = LocalDate.now();
+        int shift = today.getDayOfWeek().getValue() % 7; // 일=0, 월=1, ..., 토=6
+        LocalDate sunday = today.minusDays(shift);
+        LocalDate nextFriday = today.with(TemporalAdjusters.nextOrSame(java.time.DayOfWeek.FRIDAY));
+        LocalDate nextSaturday = today.with(TemporalAdjusters.nextOrSame(java.time.DayOfWeek.SATURDAY));
+
+        // 오늘 10:00 CONFIRMED (정우진)
+        save(Reservation.create(m2, photographer, itemsByName.get("프로필 촬영"), today.atTime(10, 0),
+                60, "서울 스튜디오", 80000, "프로필 촬영 요청"), ReservationStatus.CONFIRMED);
+
+        // 오늘 13:00 CONFIRMED 2시간 (이수빈)
+        save(Reservation.create(m1, photographer, itemsByName.get("데이트 스냅"), today.atTime(13, 0),
+                120, "홍대 / 연남동", 150000, "데이트 스냅 요청"), ReservationStatus.CONFIRMED);
+
+        // 이번 주 월요일 10:00 CONFIRMED 2시간 (이수빈)
+        save(Reservation.create(m1, photographer, itemsByName.get("졸업사진"), sunday.plusDays(1).atTime(10, 0),
+                120, "광화문", 180000, "졸업사진 촬영"), ReservationStatus.CONFIRMED);
+
+        // 이번 주 토요일 11:00 CONFIRMED (강지우)
+        save(Reservation.create(m3, photographer, itemsByName.get("가족사진"), sunday.plusDays(6).atTime(11, 0),
+                60, "분당 율동공원", 130000, "가족사진 촬영"), ReservationStatus.CONFIRMED);
+
+        // 다가오는 금요일 09:00 PENDING (정우진)
+        save(Reservation.create(m2, photographer, itemsByName.get("증명사진"), nextFriday.atTime(9, 0),
+                60, "강남 스튜디오", 50000, "증명사진 요청"), ReservationStatus.PENDING);
+
+        // 다가오는 토요일 14:00 PENDING (강지우)
+        save(Reservation.create(m3, photographer, itemsByName.get("웨딩 스냅"), nextSaturday.atTime(14, 0),
+                60, "한강공원", 200000, "웨딩 스냅 요청"), ReservationStatus.PENDING);
+
+        // 지난주 COMPLETED (정우진)
+        save(Reservation.create(m2, photographer, itemsByName.get("프로필 촬영"), sunday.minusDays(5).atTime(11, 0),
+                60, "부산 해운대", 120000, "지난주 촬영"), ReservationStatus.COMPLETED);
+
+        // 지난주 REJECTED (강지우)
+        save(Reservation.create(m3, photographer, itemsByName.get("웨딩 스냅"), sunday.minusDays(2).atTime(15, 0),
+                60, "성수동", 100000, "거절 케이스"), ReservationStatus.REJECTED);
+
+        log.info("[seed] reservation dev seeding complete (7 records)");
+    }
+
+    private Map<String, Item> ensureItems(Photographer photographer) {
+        Map<String, Item> itemsByName = new LinkedHashMap<>();
+        for (Item item : itemRepository.findByPhotographerId(photographer.getId())) {
+            itemsByName.putIfAbsent(item.getName(), item);
+        }
+
+        ensureItem(itemsByName, photographer, "프로필", "프로필 촬영",
+                "전문 프로필 사진 촬영", "보정 3컷 포함", "의상 및 메이크업 별도",
+                ItemType.IN, 24, "촬영 3일 전부터 환불 불가",
+                "서울특별시 강남구 테헤란로 1", 37.5000, 127.0370,
+                "1인 프로필", 80000, 60, 120, 3, 3);
+        ensureItem(itemsByName, photographer, "데이트", "데이트 스냅",
+                "자연스러운 커플 스냅 촬영", "원본 전체 제공", "입장료 별도",
+                ItemType.OUT, 48, "촬영 5일 전부터 일정 변경만 가능",
+                "서울특별시 마포구 양화로 188", 37.5570, 126.9245,
+                "커플 2시간", 150000, 120, 250, 10, 5);
+        ensureItem(itemsByName, photographer, "증명", "증명사진",
+                "빠르게 완성하는 증명사진 촬영", "기본 보정 포함", "인화 배송 별도",
+                ItemType.IN, 12, "촬영 전날까지 취소 가능",
+                "서울특별시 강남구 봉은사로 112", 37.5045, 127.0280,
+                "기본 증명", 50000, 30, 20, 2, 2);
+        ensureItem(itemsByName, photographer, "웨딩", "웨딩 스냅",
+                "본식 전후 웨딩 스냅 촬영", "보정본 20컷 포함", "드레스 및 부케 별도",
+                ItemType.OUT, 72, "촬영 7일 전부터 환불 불가",
+                "서울특별시 용산구 서빙고로 137", 37.5204, 126.9946,
+                "웨딩 하프데이", 200000, 180, 400, 20, 7);
+        ensureItem(itemsByName, photographer, "졸업", "졸업사진",
+                "졸업 시즌 야외/실내 촬영", "보정본 8컷 포함", "학사복 대여 별도",
+                ItemType.OUT, 24, "우천 시 일정 조율",
+                "서울특별시 종로구 세종대로 175", 37.5720, 126.9769,
+                "졸업 2시간", 180000, 120, 220, 8, 4);
+        ensureItem(itemsByName, photographer, "가족", "가족사진",
+                "자연스러운 가족 야외 촬영", "보정본 6컷 포함", "소품은 개별 준비",
+                ItemType.OUT, 24, "촬영 2일 전까지 변경 가능",
+                "경기도 성남시 분당구 문정로 145", 37.3786, 127.1492,
+                "가족 1시간", 130000, 60, 150, 6, 4);
+
+        return itemsByName;
+    }
+
+    private void ensureItem(Map<String, Item> itemsByName,
+                            Photographer photographer,
+                            String tagName,
+                            String itemName,
+                            String description,
+                            String includes,
+                            String excludes,
+                            ItemType itemType,
+                            int minBookingLeadTime,
+                            String cancellationPolicy,
+                            String address,
+                            double lat,
+                            double lng,
+                            String planName,
+                            int price,
+                            int shootingDuration,
+                            int originalPhotoCount,
+                            int editedPhotoCount,
+                            int deliveryDays) {
+        if (itemsByName.containsKey(itemName)) {
+            return;
+        }
+
+        Tag tag = ensureTag(tagName);
+        Item item = Item.createItem(
+                photographer, tag, itemName, description,
+                includes, excludes, itemType, minBookingLeadTime,
+                cancellationPolicy, address, lat, lng
+        );
+        Plan.createPlan(item, planName, price, shootingDuration, originalPhotoCount, editedPhotoCount, deliveryDays);
+        itemRepository.save(item);
+        itemsByName.put(itemName, item);
+        log.info("[seed] created dev item: {}", itemName);
+    }
+
+    private Tag ensureTag(String name) {
+        return tagRepository.findTagByName(name)
+                .orElseGet(() -> tagRepository.save(Tag.createTag(name)));
+    }
+
+    private void save(Reservation r, ReservationStatus targetStatus) {
+        switch (targetStatus) {
+            case CONFIRMED -> r.approve();
+            case REJECTED -> r.reject();
+            case COMPLETED -> {
+                r.approve();
+                r.markCompleted();
+            }
+            case PENDING, CANCELED -> {
+            }
+        }
+        reservationRepository.save(r);
+    }
+
+    private Photographer ensurePhotographer() {
+        Account acc = accountRepository.findByUsername("dev_photo");
+        if (acc == null) {
+            acc = Account.createAccount("dev_photo",
+                    passwordEncoder.encode("password1a"), Role.PHOTOGRAPHER);
+            accountRepository.save(acc);
+        }
+
+        Photographer photographer = photographerRepository.findByAccountUsername("dev_photo");
+        if (photographer == null) {
+            Photographer p = Photographer.createMember(acc, "devphoto@test.com",
+                    "테스트작가", Gender.MALE, "010-0000-0001", 0);
+            photographerRepository.save(p);
+            log.info("[seed] created dev photographer account");
+            photographer = p;
+        }
+        return photographer;
+    }
+
+    private Member ensureMember(String username, String name, String email) {
+        Account acc = accountRepository.findByUsername(username);
+        if (acc == null) {
+            acc = Account.createAccount(username,
+                    passwordEncoder.encode("password1a"), Role.MEMBER);
+            accountRepository.save(acc);
+        }
+
+        Member member = memberRepository.findByAccount(acc);
+        if (member == null) {
+            Member m = Member.createMember(acc, email, name, Gender.FEMALE, "010-1111-1111", 500000);
+            memberRepository.save(m);
+            log.info("[seed] created dev member: {}", username);
+            member = m;
+        }
+        return member;
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/global/scheduler/ReservationAutoCompleteScheduler.java
+++ b/src/main/java/com/pickkasso/pickkasso/global/scheduler/ReservationAutoCompleteScheduler.java
@@ -1,0 +1,33 @@
+package com.pickkasso.pickkasso.global.scheduler;
+
+import com.pickkasso.pickkasso.user.entity.Reservation;
+import com.pickkasso.pickkasso.user.entity.ReservationStatus;
+import com.pickkasso.pickkasso.user.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ReservationAutoCompleteScheduler {
+
+    private final ReservationRepository reservationRepository;
+
+    @Scheduled(fixedDelay = 60_000)
+    @Transactional
+    public void autoComplete() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Reservation> candidates = reservationRepository
+                .findByStatusAndScheduledAtBefore(ReservationStatus.CONFIRMED, now);
+
+        for (Reservation r : candidates) {
+            if (r.getScheduledAt().plusMinutes(r.getDurationMinutes()).isBefore(now)) {
+                r.markCompleted();
+            }
+        }
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/item/repository/PlanRepository.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/repository/PlanRepository.java
@@ -1,0 +1,14 @@
+package com.pickkasso.pickkasso.item.repository;
+
+import com.pickkasso.pickkasso.item.entity.Plan;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+
+    @Query("SELECT p FROM Plan p JOIN FETCH p.item i JOIN FETCH i.photographer ph WHERE p.id = :id")
+    Optional<Plan> findByIdWithItemAndPhotographer(@Param("id") Long id);
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerDashboardController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerDashboardController.java
@@ -4,13 +4,16 @@ import com.pickkasso.pickkasso.user.dto.photographer.ProfileCompletionDto;
 import com.pickkasso.pickkasso.user.entity.Photographer;
 import com.pickkasso.pickkasso.user.repository.PhotographerRepository;
 import com.pickkasso.pickkasso.user.service.PhotographerProfileService;
+import com.pickkasso.pickkasso.user.service.PhotographerReservationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequiredArgsConstructor
@@ -19,23 +22,62 @@ public class PhotographerDashboardController {
 
     private final PhotographerRepository photographerRepository;
     private final PhotographerProfileService photographerProfileService;
+    private final PhotographerReservationService reservationService;
 
     @GetMapping("/{photographerId}/dashboard")
     public String dashboard(@PathVariable Long photographerId, Authentication auth, Model model) {
-        if (auth != null && auth.isAuthenticated()) {
-            Photographer photographer = photographerRepository.findByAccountUsername(auth.getName());
-
-            if (photographer == null || !photographer.getId().equals(photographerId)) {
-                return "redirect:/";
-            }
-
-            ProfileCompletionDto completion = photographerProfileService.getProfileCompletion(photographerId);
-
-            model.addAttribute("photographer", photographer);
-            model.addAttribute("completion", completion);
-            model.addAttribute("activeTab", "dashboard");
-            return "photographer/dashboard";
+        if (auth == null || !auth.isAuthenticated()) {
+            return "redirect:/login";
         }
-        return "redirect:/login";
+        Photographer photographer = photographerRepository.findByAccountUsername(auth.getName());
+        if (photographer == null || !photographer.getId().equals(photographerId)) {
+            return "redirect:/";
+        }
+
+        ProfileCompletionDto completion = photographerProfileService.getProfileCompletion(photographerId);
+
+        model.addAttribute("photographer", photographer);
+        model.addAttribute("completion", completion);
+        model.addAttribute("activeTab", "dashboard");
+        model.addAttribute("summary", reservationService.getSummary(photographerId));
+        model.addAttribute("pendingList", reservationService.getPendingList(photographerId));
+        model.addAttribute("todaySchedule", reservationService.getTodaySchedule(photographerId));
+        model.addAttribute("weekly", reservationService.getWeeklyCalendar(photographerId));
+
+        return "photographer/dashboard";
+    }
+
+    @PostMapping("/{photographerId}/reservations/{reservationId}/accept")
+    public String accept(@PathVariable Long photographerId,
+                         @PathVariable Long reservationId,
+                         Authentication auth,
+                         RedirectAttributes ra) {
+        if (auth == null || !auth.isAuthenticated()) return "redirect:/login";
+        Photographer me = photographerRepository.findByAccountUsername(auth.getName());
+        if (me == null || !me.getId().equals(photographerId)) return "redirect:/";
+        try {
+            reservationService.approve(photographerId, reservationId);
+            ra.addFlashAttribute("toast", "예약을 수락했습니다.");
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            ra.addFlashAttribute("toastError", e.getMessage());
+        }
+        return "redirect:/photographer/" + photographerId + "/dashboard";
+    }
+
+    @PostMapping("/{photographerId}/reservations/{reservationId}/reject")
+    public String reject(@PathVariable Long photographerId,
+                         @PathVariable Long reservationId,
+                         Authentication auth,
+                         RedirectAttributes ra) {
+        if (auth == null || !auth.isAuthenticated()) return "redirect:/login";
+        Photographer me = photographerRepository.findByAccountUsername(auth.getName());
+        if (me == null || !me.getId().equals(photographerId)) return "redirect:/";
+        try {
+            reservationService.reject(photographerId, reservationId);
+            ra.addFlashAttribute("toast", "예약을 거절했습니다.");
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            ra.addFlashAttribute("toastError", e.getMessage());
+        }
+        return "redirect:/photographer/" + photographerId + "/dashboard";
     }
 }

--- a/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerDashboardController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerDashboardController.java
@@ -9,11 +9,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.time.LocalDate;
 
 @Controller
 @RequiredArgsConstructor
@@ -25,31 +29,40 @@ public class PhotographerDashboardController {
     private final PhotographerReservationService reservationService;
 
     @GetMapping("/{photographerId}/dashboard")
-    public String dashboard(@PathVariable Long photographerId, Authentication auth, Model model) {
-        if (auth == null || !auth.isAuthenticated()) {
-            return "redirect:/login";
-        }
-        Photographer photographer = photographerRepository.findByAccountUsername(auth.getName());
-        if (photographer == null || !photographer.getId().equals(photographerId)) {
-            return "redirect:/";
-        }
+    public String dashboard(@PathVariable Long photographerId,
+                            @RequestParam(required = false)
+                            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStart,
+                            Authentication auth,
+                            Model model) {
+        Photographer photographer = resolveAuthorizedPhotographer(photographerId, auth);
+        if (photographer == null) return auth == null || !auth.isAuthenticated() ? "redirect:/login" : "redirect:/";
 
-        ProfileCompletionDto completion = photographerProfileService.getProfileCompletion(photographerId);
-
-        model.addAttribute("photographer", photographer);
-        model.addAttribute("completion", completion);
-        model.addAttribute("activeTab", "dashboard");
-        model.addAttribute("summary", reservationService.getSummary(photographerId));
-        model.addAttribute("pendingList", reservationService.getPendingList(photographerId));
-        model.addAttribute("todaySchedule", reservationService.getTodaySchedule(photographerId));
-        model.addAttribute("weekly", reservationService.getWeeklyCalendar(photographerId));
+        populateDashboardModel(model, photographer, weekStart);
 
         return "photographer/dashboard";
+    }
+
+    @GetMapping("/{photographerId}/dashboard/weekly-calendar")
+    public String weeklyCalendar(@PathVariable Long photographerId,
+                                 @RequestParam(required = false)
+                                 @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStart,
+                                 Authentication auth,
+                                 Model model) {
+        Photographer photographer = resolveAuthorizedPhotographer(photographerId, auth);
+        if (photographer == null) return auth == null || !auth.isAuthenticated() ? "redirect:/login" : "redirect:/";
+
+        model.addAttribute("photographer", photographer);
+        model.addAttribute("weekly", reservationService.getWeeklyCalendar(
+                photographerId, reservationService.normalizeWeekStart(weekStart)
+        ));
+        return "photographer/dashboard :: weeklyCalendarCard";
     }
 
     @PostMapping("/{photographerId}/reservations/{reservationId}/accept")
     public String accept(@PathVariable Long photographerId,
                          @PathVariable Long reservationId,
+                         @RequestParam(required = false)
+                         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStart,
                          Authentication auth,
                          RedirectAttributes ra) {
         if (auth == null || !auth.isAuthenticated()) return "redirect:/login";
@@ -61,12 +74,14 @@ public class PhotographerDashboardController {
         } catch (IllegalArgumentException | IllegalStateException e) {
             ra.addFlashAttribute("toastError", e.getMessage());
         }
-        return "redirect:/photographer/" + photographerId + "/dashboard";
+        return redirectToDashboard(photographerId, weekStart);
     }
 
     @PostMapping("/{photographerId}/reservations/{reservationId}/reject")
     public String reject(@PathVariable Long photographerId,
                          @PathVariable Long reservationId,
+                         @RequestParam(required = false)
+                         @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStart,
                          Authentication auth,
                          RedirectAttributes ra) {
         if (auth == null || !auth.isAuthenticated()) return "redirect:/login";
@@ -78,6 +93,38 @@ public class PhotographerDashboardController {
         } catch (IllegalArgumentException | IllegalStateException e) {
             ra.addFlashAttribute("toastError", e.getMessage());
         }
-        return "redirect:/photographer/" + photographerId + "/dashboard";
+        return redirectToDashboard(photographerId, weekStart);
+    }
+
+    private String redirectToDashboard(Long photographerId, LocalDate weekStart) {
+        if (weekStart == null) {
+            return "redirect:/photographer/" + photographerId + "/dashboard";
+        }
+        return "redirect:/photographer/" + photographerId + "/dashboard?weekStart=" + weekStart;
+    }
+
+    private Photographer resolveAuthorizedPhotographer(Long photographerId, Authentication auth) {
+        if (auth == null || !auth.isAuthenticated()) {
+            return null;
+        }
+        Photographer photographer = photographerRepository.findByAccountUsername(auth.getName());
+        if (photographer == null || !photographer.getId().equals(photographerId)) {
+            return null;
+        }
+        return photographer;
+    }
+
+    private void populateDashboardModel(Model model, Photographer photographer, LocalDate weekStart) {
+        Long photographerId = photographer.getId();
+        LocalDate normalizedWeekStart = reservationService.normalizeWeekStart(weekStart);
+        ProfileCompletionDto completion = photographerProfileService.getProfileCompletion(photographerId);
+
+        model.addAttribute("photographer", photographer);
+        model.addAttribute("completion", completion);
+        model.addAttribute("activeTab", "dashboard");
+        model.addAttribute("summary", reservationService.getSummary(photographerId));
+        model.addAttribute("pendingList", reservationService.getPendingList(photographerId));
+        model.addAttribute("todaySchedule", reservationService.getTodaySchedule(photographerId));
+        model.addAttribute("weekly", reservationService.getWeeklyCalendar(photographerId, normalizedWeekStart));
     }
 }

--- a/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerDashboardController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerDashboardController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.time.LocalDate;
@@ -44,14 +45,21 @@ public class PhotographerDashboardController {
 
     @GetMapping("/{photographerId}/reservations")
     public String reservations(@PathVariable Long photographerId,
+                               @RequestParam(required = false) String status,
+                               @RequestParam(required = false) String keyword,
                                Authentication auth,
                                Model model) {
         Photographer photographer = resolveAuthorizedPhotographer(photographerId, auth);
         if (photographer == null) return auth == null || !auth.isAuthenticated() ? "redirect:/login" : "redirect:/";
 
         model.addAttribute("photographer", photographer);
+        model.addAttribute("userId", photographerId);
         model.addAttribute("activeTab", "reservations");
         model.addAttribute("summary", reservationService.getSummary(photographerId));
+        model.addAttribute("reservationManagementSummary", reservationService.getManagementSummary(photographerId));
+        model.addAttribute("reservationItems", reservationService.getManagementReservations(photographerId, status, keyword));
+        model.addAttribute("selectedStatus", reservationService.normalizeStatusFilter(status));
+        model.addAttribute("keyword", keyword == null ? "" : keyword.trim());
 
         return "photographer/reservations";
     }
@@ -77,6 +85,9 @@ public class PhotographerDashboardController {
                          @PathVariable Long reservationId,
                          @RequestParam(required = false)
                          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStart,
+                         @RequestParam(required = false) String redirectTo,
+                         @RequestParam(required = false) String status,
+                         @RequestParam(required = false) String keyword,
                          Authentication auth,
                          RedirectAttributes ra) {
         if (auth == null || !auth.isAuthenticated()) return "redirect:/login";
@@ -88,7 +99,7 @@ public class PhotographerDashboardController {
         } catch (IllegalArgumentException | IllegalStateException e) {
             ra.addFlashAttribute("toastError", e.getMessage());
         }
-        return redirectToDashboard(photographerId, weekStart);
+        return redirectAfterReservationAction(photographerId, redirectTo, weekStart, status, keyword);
     }
 
     @PostMapping("/{photographerId}/reservations/{reservationId}/reject")
@@ -96,6 +107,9 @@ public class PhotographerDashboardController {
                          @PathVariable Long reservationId,
                          @RequestParam(required = false)
                          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStart,
+                         @RequestParam(required = false) String redirectTo,
+                         @RequestParam(required = false) String status,
+                         @RequestParam(required = false) String keyword,
                          Authentication auth,
                          RedirectAttributes ra) {
         if (auth == null || !auth.isAuthenticated()) return "redirect:/login";
@@ -107,7 +121,7 @@ public class PhotographerDashboardController {
         } catch (IllegalArgumentException | IllegalStateException e) {
             ra.addFlashAttribute("toastError", e.getMessage());
         }
-        return redirectToDashboard(photographerId, weekStart);
+        return redirectAfterReservationAction(photographerId, redirectTo, weekStart, status, keyword);
     }
 
     private String redirectToDashboard(Long photographerId, LocalDate weekStart) {
@@ -115,6 +129,20 @@ public class PhotographerDashboardController {
             return "redirect:/photographer/" + photographerId + "/dashboard";
         }
         return "redirect:/photographer/" + photographerId + "/dashboard?weekStart=" + weekStart;
+    }
+
+    private String redirectAfterReservationAction(Long photographerId,
+                                                  String redirectTo,
+                                                  LocalDate weekStart,
+                                                  String status,
+                                                  String keyword) {
+        if ("reservations".equalsIgnoreCase(redirectTo)) {
+            UriComponentsBuilder builder = UriComponentsBuilder.fromPath("/photographer/{photographerId}/reservations")
+                    .queryParamIfPresent("status", java.util.Optional.ofNullable(status).filter(s -> !s.isBlank()))
+                    .queryParamIfPresent("keyword", java.util.Optional.ofNullable(keyword).filter(s -> !s.isBlank()));
+            return "redirect:" + builder.buildAndExpand(photographerId).encode().toUriString();
+        }
+        return redirectToDashboard(photographerId, weekStart);
     }
 
     private Photographer resolveAuthorizedPhotographer(Long photographerId, Authentication auth) {
@@ -134,6 +162,7 @@ public class PhotographerDashboardController {
         ProfileCompletionDto completion = photographerProfileService.getProfileCompletion(photographerId);
 
         model.addAttribute("photographer", photographer);
+        model.addAttribute("userId", photographerId);
         model.addAttribute("completion", completion);
         model.addAttribute("activeTab", "dashboard");
         model.addAttribute("summary", reservationService.getSummary(photographerId));

--- a/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerDashboardController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerDashboardController.java
@@ -80,6 +80,21 @@ public class PhotographerDashboardController {
         return "photographer/dashboard :: weeklyCalendarCard";
     }
 
+    @GetMapping("/{photographerId}/reviews")
+    public String reviews(@PathVariable Long photographerId,
+                          Authentication auth,
+                          Model model) {
+        Photographer photographer = resolveAuthorizedPhotographer(photographerId, auth);
+        if (photographer == null) return auth == null || !auth.isAuthenticated() ? "redirect:/login" : "redirect:/";
+
+        model.addAttribute("photographer", photographer);
+        model.addAttribute("userId", photographerId);
+        model.addAttribute("activeTab", "reviews");
+        model.addAttribute("summary", reservationService.getSummary(photographerId));
+
+        return "photographer/reviews";
+    }
+
     @GetMapping("/{photographerId}/settlement")
     public String settlement(@PathVariable Long photographerId,
                              Authentication auth,

--- a/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerDashboardController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerDashboardController.java
@@ -42,6 +42,20 @@ public class PhotographerDashboardController {
         return "photographer/dashboard";
     }
 
+    @GetMapping("/{photographerId}/reservations")
+    public String reservations(@PathVariable Long photographerId,
+                               Authentication auth,
+                               Model model) {
+        Photographer photographer = resolveAuthorizedPhotographer(photographerId, auth);
+        if (photographer == null) return auth == null || !auth.isAuthenticated() ? "redirect:/login" : "redirect:/";
+
+        model.addAttribute("photographer", photographer);
+        model.addAttribute("activeTab", "reservations");
+        model.addAttribute("summary", reservationService.getSummary(photographerId));
+
+        return "photographer/reservations";
+    }
+
     @GetMapping("/{photographerId}/dashboard/weekly-calendar")
     public String weeklyCalendar(@PathVariable Long photographerId,
                                  @RequestParam(required = false)

--- a/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerDashboardController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerDashboardController.java
@@ -80,6 +80,21 @@ public class PhotographerDashboardController {
         return "photographer/dashboard :: weeklyCalendarCard";
     }
 
+    @GetMapping("/{photographerId}/settlement")
+    public String settlement(@PathVariable Long photographerId,
+                             Authentication auth,
+                             Model model) {
+        Photographer photographer = resolveAuthorizedPhotographer(photographerId, auth);
+        if (photographer == null) return auth == null || !auth.isAuthenticated() ? "redirect:/login" : "redirect:/";
+
+        model.addAttribute("photographer", photographer);
+        model.addAttribute("userId", photographerId);
+        model.addAttribute("activeTab", "settlement");
+        model.addAttribute("summary", reservationService.getSummary(photographerId));
+
+        return "photographer/settlement";
+    }
+
     @PostMapping("/{photographerId}/reservations/{reservationId}/accept")
     public String accept(@PathVariable Long photographerId,
                          @PathVariable Long reservationId,

--- a/src/main/java/com/pickkasso/pickkasso/user/controller/ReservationController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/ReservationController.java
@@ -1,15 +1,23 @@
 package com.pickkasso.pickkasso.user.controller;
 
+import com.pickkasso.pickkasso.item.entity.Item;
+import com.pickkasso.pickkasso.item.entity.Plan;
+import com.pickkasso.pickkasso.item.service.ItemService;
+import com.pickkasso.pickkasso.user.dto.ReservationCreateRequest;
 import com.pickkasso.pickkasso.user.entity.Account;
 import com.pickkasso.pickkasso.user.entity.Member;
+import com.pickkasso.pickkasso.user.entity.Reservation;
 import com.pickkasso.pickkasso.user.repository.AccountRepository;
 import com.pickkasso.pickkasso.user.repository.MemberRepository;
+import com.pickkasso.pickkasso.user.repository.ReservationRepository;
+import com.pickkasso.pickkasso.user.service.PhotographerProfileService;
+import com.pickkasso.pickkasso.user.service.UserReservationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 @RequiredArgsConstructor
@@ -17,11 +25,68 @@ public class ReservationController {
 
     private final AccountRepository accountRepository;
     private final MemberRepository memberRepository;
+    private final ItemService itemService;
+    private final PhotographerProfileService photographerProfileService;
+    private final UserReservationService userReservationService;
+    private final ReservationRepository reservationRepository;
 
     @GetMapping("/items/{itemId}/reserve")
-    public String reservationPage(@PathVariable Long itemId, Authentication auth, Model model) {
+    public String reservationPage(
+            @PathVariable Long itemId,
+            @RequestParam(required = false) Long planId,
+            Authentication auth,
+            Model model) {
+
+        Item item = itemService.getItemById(itemId);
+
+        Plan selectedPlan = null;
+        if (planId != null) {
+            selectedPlan = item.getPlanList().stream()
+                    .filter(p -> p.getId().equals(planId))
+                    .findFirst().orElse(null);
+        }
+        if (selectedPlan == null && !item.getPlanList().isEmpty()) {
+            selectedPlan = item.getPlanList().get(0);
+        }
+
+        model.addAttribute("item", item);
+        model.addAttribute("selectedPlan", selectedPlan);
         model.addAttribute("member", resolveMember(auth));
+        model.addAttribute("profile", photographerProfileService.getProfileForm(item.getPhotographer().getId()));
         return "user/reservation";
+    }
+
+    @PostMapping("/items/{itemId}/reserve")
+    public String createReservation(
+            @PathVariable Long itemId,
+            @ModelAttribute ReservationCreateRequest request,
+            Authentication auth,
+            RedirectAttributes redirectAttrs) {
+
+        Member member = resolveMember(auth);
+        if (member == null) {
+            return "redirect:/login";
+        }
+
+        try {
+            Long reservationId = userReservationService.createReservation(member.getId(), request);
+            return "redirect:/reservations/" + reservationId + "/complete";
+        } catch (Exception e) {
+            redirectAttrs.addFlashAttribute("errorMsg", e.getMessage());
+            return "redirect:/items/" + itemId + "/reserve?planId=" + request.getPlanId();
+        }
+    }
+
+    @GetMapping("/reservations/{reservationId}/complete")
+    public String reservationComplete(
+            @PathVariable Long reservationId,
+            Model model) {
+
+        Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
+                .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다."));
+
+        model.addAttribute("reservation", reservation);
+        return "user/reservation-complete";
     }
 
     private Member resolveMember(Authentication auth) {

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/ReservationCreateRequest.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/ReservationCreateRequest.java
@@ -1,0 +1,16 @@
+package com.pickkasso.pickkasso.user.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReservationCreateRequest {
+    private Long planId;
+    private String scheduledDate;   // YYYY-MM-DD
+    private Integer scheduledHour;  // 9 ~ 20
+    private String address;
+    private String detailAddress;
+    private Integer headCount;
+    private String memo;
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/CalendarEventDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/CalendarEventDto.java
@@ -1,0 +1,11 @@
+package com.pickkasso.pickkasso.user.dto.photographer;
+
+public record CalendarEventDto(
+        Long reservationId,
+        int dayIndex,
+        int hourSlot,
+        int rowSpanHours,
+        String title,
+        String subtitle,
+        String colorClass
+) {}

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/CalendarEventDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/CalendarEventDto.java
@@ -7,5 +7,6 @@ public record CalendarEventDto(
         int rowSpanHours,
         String title,
         String subtitle,
+        String timeLabel,
         String colorClass
 ) {}

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/DashboardSummaryDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/DashboardSummaryDto.java
@@ -1,0 +1,3 @@
+package com.pickkasso.pickkasso.user.dto.photographer;
+
+public record DashboardSummaryDto(long todayCount, long pendingCount) {}

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/DashboardSummaryDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/DashboardSummaryDto.java
@@ -1,3 +1,3 @@
 package com.pickkasso.pickkasso.user.dto.photographer;
 
-public record DashboardSummaryDto(long todayCount, long pendingCount) {}
+public record DashboardSummaryDto(long todayCount, long pendingCount, long monthlyRevenue) {}

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/DashboardSummaryDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/DashboardSummaryDto.java
@@ -1,3 +1,3 @@
 package com.pickkasso.pickkasso.user.dto.photographer;
 
-public record DashboardSummaryDto(long todayCount, long pendingCount, long monthlyRevenue) {}
+public record DashboardSummaryDto(long todayCount, long pendingCount, long monthlyRevenue, long withdrawableAmount) {}

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/DayHeaderDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/DayHeaderDto.java
@@ -1,0 +1,10 @@
+package com.pickkasso.pickkasso.user.dto.photographer;
+
+public record DayHeaderDto(
+        int dayIndex,
+        String labelKor,
+        int dayOfMonth,
+        boolean isToday,
+        boolean isSunday,
+        boolean isSaturday
+) {}

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/PendingReservationDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/PendingReservationDto.java
@@ -1,0 +1,35 @@
+package com.pickkasso.pickkasso.user.dto.photographer;
+
+import com.pickkasso.pickkasso.user.entity.Reservation;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public record PendingReservationDto(
+        Long reservationId,
+        String memberName,
+        String memberInitial,
+        String itemName,
+        String scheduledLabel,
+        LocalDateTime scheduledAt
+) {
+    private static final String[] WEEKDAY_KOR = {"월", "화", "수", "목", "금", "토", "일"};
+    private static final DateTimeFormatter TIME_FMT = DateTimeFormatter.ofPattern("HH:mm");
+
+    public static PendingReservationDto of(Reservation r) {
+        String memberName = r.getMember().getName();
+        String initial = memberName.isEmpty() ? "?" : String.valueOf(memberName.charAt(0));
+        LocalDateTime at = r.getScheduledAt();
+        String dayOfWeek = WEEKDAY_KOR[at.getDayOfWeek().getValue() - 1];
+        String scheduledLabel = at.getMonthValue() + "/" + at.getDayOfMonth()
+                + "(" + dayOfWeek + ") " + at.format(TIME_FMT);
+        return new PendingReservationDto(
+                r.getId(),
+                memberName,
+                initial,
+                r.getItem().getName(),
+                scheduledLabel,
+                at
+        );
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/ReservationManagementItemDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/ReservationManagementItemDto.java
@@ -1,0 +1,104 @@
+package com.pickkasso.pickkasso.user.dto.photographer;
+
+import com.pickkasso.pickkasso.user.entity.Reservation;
+import com.pickkasso.pickkasso.user.entity.ReservationStatus;
+
+import java.text.NumberFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public record ReservationManagementItemDto(
+        Long reservationId,
+        ReservationStatus status,
+        String statusLabel,
+        String statusClassName,
+        String statusHint,
+        String statusHintColorClass,
+        String memberName,
+        String memberInitial,
+        String itemName,
+        String scheduleLabel,
+        String address,
+        String priceLabel,
+        String memo,
+        boolean actionable
+) {
+    private static final String[] WEEKDAY_KOR = {"월", "화", "수", "목", "금", "토", "일"};
+    private static final DateTimeFormatter TIME_FMT = DateTimeFormatter.ofPattern("HH:mm");
+    private static final NumberFormat PRICE_FMT = NumberFormat.getNumberInstance(Locale.KOREA);
+
+    public static ReservationManagementItemDto of(Reservation reservation) {
+        LocalDateTime start = reservation.getScheduledAt();
+        LocalDateTime end = start.plusMinutes(reservation.getDurationMinutes());
+        String weekday = WEEKDAY_KOR[start.getDayOfWeek().getValue() - 1];
+        String scheduleLabel = start.getMonthValue() + "월 " + start.getDayOfMonth() + "일 (" + weekday + ") "
+                + start.format(TIME_FMT) + " - " + end.format(TIME_FMT);
+        String memberName = reservation.getMember().getName();
+        String initial = memberName.isEmpty() ? "?" : String.valueOf(memberName.charAt(0));
+        String memo = reservation.getMemo() != null && !reservation.getMemo().isBlank()
+                ? reservation.getMemo()
+                : defaultMemo(reservation.getStatus(), reservation.getItem().getName());
+
+        return new ReservationManagementItemDto(
+                reservation.getId(),
+                reservation.getStatus(),
+                reservation.getStatus().label(),
+                toStatusClassName(reservation.getStatus()),
+                toStatusHint(reservation),
+                toStatusHintColorClass(reservation.getStatus()),
+                memberName,
+                initial,
+                reservation.getItem().getName(),
+                scheduleLabel,
+                reservation.getAddress(),
+                PRICE_FMT.format(reservation.getTotalPrice()) + "C",
+                memo,
+                reservation.getStatus() == ReservationStatus.PENDING
+        );
+    }
+
+    private static String toStatusClassName(ReservationStatus status) {
+        return switch (status) {
+            case PENDING -> "pending";
+            case CONFIRMED -> "confirmed";
+            case COMPLETED -> "completed";
+            case REJECTED, CANCELED -> "rejected";
+        };
+    }
+
+    private static String toStatusHint(Reservation reservation) {
+        LocalDate today = LocalDate.now();
+        return switch (reservation.getStatus()) {
+            case PENDING -> reservation.getRequestedAt().toLocalDate().isBefore(today)
+                    ? "빠른 응답 필요"
+                    : "승인 검토 중";
+            case CONFIRMED -> reservation.getScheduledAt().toLocalDate().equals(today.plusDays(1))
+                    ? "D-1 리마인드 예정"
+                    : "촬영 준비 진행 중";
+            case COMPLETED -> "후속 작업 진행 중";
+            case REJECTED -> "응답 완료";
+            case CANCELED -> "사용자 취소";
+        };
+    }
+
+    private static String toStatusHintColorClass(ReservationStatus status) {
+        return switch (status) {
+            case PENDING -> "text-[#FF6B2B]";
+            case CONFIRMED -> "text-[#1D3CFF]";
+            case COMPLETED -> "text-[#1A8E40]";
+            case REJECTED, CANCELED -> "text-[#888]";
+        };
+    }
+
+    private static String defaultMemo(ReservationStatus status, String itemName) {
+        return switch (status) {
+            case PENDING -> itemName + " 예약 요청이 접수되었습니다. 고객 요청사항을 확인하고 승인 여부를 결정해 주세요.";
+            case CONFIRMED -> itemName + " 예약이 확정되었습니다. 촬영 전 안내 메시지와 준비 사항을 점검해 주세요.";
+            case COMPLETED -> itemName + " 촬영이 완료되었습니다. 후속 전달 일정과 정산 상태를 확인해 주세요.";
+            case REJECTED -> itemName + " 예약을 거절한 건입니다. 필요 시 고객 안내 문구를 다시 확인해 주세요.";
+            case CANCELED -> itemName + " 예약이 취소된 건입니다. 환불 및 일정 비움 처리를 함께 점검해 주세요.";
+        };
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/ReservationManagementSummaryDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/ReservationManagementSummaryDto.java
@@ -1,0 +1,11 @@
+package com.pickkasso.pickkasso.user.dto.photographer;
+
+public record ReservationManagementSummaryDto(
+        long totalCount,
+        long pendingCount,
+        long confirmedCountThisWeek,
+        int completionRate,
+        long urgentPendingCount,
+        long todayShootCount,
+        long expectedWeekRevenue
+) {}

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/TodayScheduleDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/TodayScheduleDto.java
@@ -1,0 +1,31 @@
+package com.pickkasso.pickkasso.user.dto.photographer;
+
+import com.pickkasso.pickkasso.user.entity.Reservation;
+
+public record TodayScheduleDto(
+        Long reservationId,
+        String timeLabel,
+        String ampm,
+        String itemName,
+        String address,
+        String memberName,
+        String dotColorHex
+) {
+    private static final String[] DOT_COLORS = {"#1D3CFF", "#22C55E", "#FF6B2B", "#0097FF"};
+
+    public static TodayScheduleDto of(Reservation r) {
+        int hour = r.getScheduledAt().getHour();
+        String timeLabel = String.format("%02d:%02d", hour, r.getScheduledAt().getMinute());
+        String ampm = hour < 12 ? "AM" : "PM";
+        String dotColor = DOT_COLORS[(int) (r.getItem().getId() % 4)];
+        return new TodayScheduleDto(
+                r.getId(),
+                timeLabel,
+                ampm,
+                r.getItem().getName(),
+                r.getAddress(),
+                r.getMember().getName(),
+                dotColor
+        );
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/WeeklyCalendarDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/WeeklyCalendarDto.java
@@ -55,14 +55,13 @@ public record WeeklyCalendarDto(
                     ? "gray"
                     : COLOR_CLASSES[(int) (r.getItem().getId() % 5)];
             String startTime = r.getScheduledAt().format(TIME_FMT);
-            String subtitle = r.getStatus() == ReservationStatus.COMPLETED
-                    ? r.getMember().getName() + " · 완료"
-                    : r.getMember().getName() + " · " + startTime;
+            String memberName = r.getMember().getName();
+            String timeLabel = r.getStatus() == ReservationStatus.COMPLETED ? "완료" : startTime;
 
             String key = dayIdx + "-" + hour;
             eventMap.putIfAbsent(key, new CalendarEventDto(
                     r.getId(), dayIdx, hour, rowSpan,
-                    r.getItem().getName(), subtitle, colorClass
+                    r.getItem().getName(), memberName, timeLabel, colorClass
             ));
         }
 

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/WeeklyCalendarDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/WeeklyCalendarDto.java
@@ -1,0 +1,63 @@
+package com.pickkasso.pickkasso.user.dto.photographer;
+
+import com.pickkasso.pickkasso.user.entity.Reservation;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.stream.IntStream;
+
+public record WeeklyCalendarDto(
+        LocalDate weekStart,
+        String rangeLabel,
+        List<DayHeaderDto> dayHeaders,
+        List<Integer> hourSlots,
+        Map<String, CalendarEventDto> eventByCellKey,
+        LocalDate today
+) {
+    private static final String[] DAY_NAMES_KOR = {"일", "월", "화", "수", "목", "금", "토"};
+    private static final String[] COLOR_CLASSES = {"blue", "green", "orange", "sky", "purple"};
+    private static final DateTimeFormatter TIME_FMT = DateTimeFormatter.ofPattern("HH:mm");
+    private static final DateTimeFormatter RANGE_FMT = DateTimeFormatter.ofPattern("yyyy년 M월 d일");
+
+    public static WeeklyCalendarDto of(LocalDate weekStart, List<Reservation> reservations) {
+        LocalDate today = LocalDate.now();
+
+        List<DayHeaderDto> headers = new ArrayList<>();
+        for (int i = 0; i < 7; i++) {
+            LocalDate d = weekStart.plusDays(i);
+            headers.add(new DayHeaderDto(i, DAY_NAMES_KOR[i], d.getDayOfMonth(),
+                    d.equals(today), i == 0, i == 6));
+        }
+
+        List<Integer> hourSlots = IntStream.rangeClosed(9, 18)
+                .boxed()
+                .toList();
+
+        Map<String, CalendarEventDto> eventMap = new LinkedHashMap<>();
+        for (Reservation r : reservations) {
+            LocalDate rDate = r.getScheduledAt().toLocalDate();
+            int dayIdx = (int) ChronoUnit.DAYS.between(weekStart, rDate);
+            if (dayIdx < 0 || dayIdx > 6) continue;
+            int hour = r.getScheduledAt().getHour();
+            if (hour < 9 || hour > 18) continue;
+
+            int rowSpan = Math.max(1, (int) Math.ceil(r.getDurationMinutes() / 60.0));
+            String colorClass = COLOR_CLASSES[(int) (r.getItem().getId() % 5)];
+            String startTime = r.getScheduledAt().format(TIME_FMT);
+            String subtitle = r.getMember().getName() + " · " + startTime;
+
+            String key = dayIdx + "-" + hour;
+            eventMap.putIfAbsent(key, new CalendarEventDto(
+                    r.getId(), dayIdx, hour, rowSpan,
+                    r.getItem().getName(), subtitle, colorClass
+            ));
+        }
+
+        LocalDate weekEnd = weekStart.plusDays(6);
+        String rangeLabel = weekStart.format(RANGE_FMT) + " – " + weekEnd.getDayOfMonth() + "일";
+
+        return new WeeklyCalendarDto(weekStart, rangeLabel, headers, hourSlots, eventMap, today);
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/WeeklyCalendarDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/WeeklyCalendarDto.java
@@ -10,11 +10,16 @@ import java.util.stream.IntStream;
 
 public record WeeklyCalendarDto(
         LocalDate weekStart,
+        String weekStartIso,
         String rangeLabel,
         List<DayHeaderDto> dayHeaders,
         List<Integer> hourSlots,
         Map<String, CalendarEventDto> eventByCellKey,
-        LocalDate today
+        LocalDate today,
+        String prevWeekStartIso,
+        String nextWeekStartIso,
+        String todayWeekStartIso,
+        boolean currentWeek
 ) {
     private static final String[] DAY_NAMES_KOR = {"일", "월", "화", "수", "목", "금", "토"};
     private static final String[] COLOR_CLASSES = {"blue", "green", "orange", "sky", "purple"};
@@ -23,6 +28,7 @@ public record WeeklyCalendarDto(
 
     public static WeeklyCalendarDto of(LocalDate weekStart, List<Reservation> reservations) {
         LocalDate today = LocalDate.now();
+        LocalDate todayWeekStart = today.minusDays(today.getDayOfWeek().getValue() % 7);
 
         List<DayHeaderDto> headers = new ArrayList<>();
         for (int i = 0; i < 7; i++) {
@@ -58,6 +64,18 @@ public record WeeklyCalendarDto(
         LocalDate weekEnd = weekStart.plusDays(6);
         String rangeLabel = weekStart.format(RANGE_FMT) + " – " + weekEnd.getDayOfMonth() + "일";
 
-        return new WeeklyCalendarDto(weekStart, rangeLabel, headers, hourSlots, eventMap, today);
+        return new WeeklyCalendarDto(
+                weekStart,
+                weekStart.toString(),
+                rangeLabel,
+                headers,
+                hourSlots,
+                eventMap,
+                today,
+                weekStart.minusWeeks(1).toString(),
+                weekStart.plusWeeks(1).toString(),
+                todayWeekStart.toString(),
+                weekStart.equals(todayWeekStart)
+        );
     }
 }

--- a/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/WeeklyCalendarDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/dto/photographer/WeeklyCalendarDto.java
@@ -1,6 +1,7 @@
 package com.pickkasso.pickkasso.user.dto.photographer;
 
 import com.pickkasso.pickkasso.user.entity.Reservation;
+import com.pickkasso.pickkasso.user.entity.ReservationStatus;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -50,9 +51,13 @@ public record WeeklyCalendarDto(
             if (hour < 9 || hour > 18) continue;
 
             int rowSpan = Math.max(1, (int) Math.ceil(r.getDurationMinutes() / 60.0));
-            String colorClass = COLOR_CLASSES[(int) (r.getItem().getId() % 5)];
+            String colorClass = r.getStatus() == ReservationStatus.COMPLETED
+                    ? "gray"
+                    : COLOR_CLASSES[(int) (r.getItem().getId() % 5)];
             String startTime = r.getScheduledAt().format(TIME_FMT);
-            String subtitle = r.getMember().getName() + " · " + startTime;
+            String subtitle = r.getStatus() == ReservationStatus.COMPLETED
+                    ? r.getMember().getName() + " · 완료"
+                    : r.getMember().getName() + " · " + startTime;
 
             String key = dayIdx + "-" + hour;
             eventMap.putIfAbsent(key, new CalendarEventDto(

--- a/src/main/java/com/pickkasso/pickkasso/user/entity/Reservation.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/entity/Reservation.java
@@ -9,14 +9,14 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "t_reservation")
+@Table(name = "t_order")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Reservation {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "reservation_id")
+    @Column(name = "order_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/pickkasso/pickkasso/user/entity/Reservation.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/entity/Reservation.java
@@ -1,0 +1,104 @@
+package com.pickkasso.pickkasso.user.entity;
+
+import com.pickkasso.pickkasso.item.entity.Item;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "t_reservation")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reservation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reservation_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "photographer_id", nullable = false)
+    private Photographer photographer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+    @Column(name = "scheduled_at", nullable = false)
+    private LocalDateTime scheduledAt;
+
+    @Column(name = "duration_minutes", nullable = false)
+    private Integer durationMinutes;
+
+    @Column(name = "address", nullable = false, length = 200)
+    private String address;
+
+    @Column(name = "total_price", nullable = false)
+    private Integer totalPrice;
+
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus status;
+
+    @Column(name = "requested_at", nullable = false)
+    private LocalDateTime requestedAt;
+
+    @Column(name = "decided_at")
+    private LocalDateTime decidedAt;
+
+    @Column(name = "memo", length = 500)
+    private String memo;
+
+    private Reservation(Member member, Photographer photographer, Item item,
+                        LocalDateTime scheduledAt, int durationMinutes,
+                        String address, int totalPrice, String memo) {
+        this.member = member;
+        this.photographer = photographer;
+        this.item = item;
+        this.scheduledAt = scheduledAt;
+        this.durationMinutes = durationMinutes;
+        this.address = address;
+        this.totalPrice = totalPrice;
+        this.memo = memo;
+        this.status = ReservationStatus.PENDING;
+        this.requestedAt = LocalDateTime.now();
+    }
+
+    public static Reservation create(Member member, Photographer photographer, Item item,
+                                     LocalDateTime scheduledAt, int durationMinutes,
+                                     String address, int totalPrice, String memo) {
+        return new Reservation(member, photographer, item,
+                scheduledAt, durationMinutes, address, totalPrice, memo);
+    }
+
+    public void approve() {
+        if (status != ReservationStatus.PENDING) {
+            throw new IllegalStateException("승인 가능한 상태가 아닙니다.");
+        }
+        this.status = ReservationStatus.CONFIRMED;
+        this.decidedAt = LocalDateTime.now();
+    }
+
+    public void reject() {
+        if (status != ReservationStatus.PENDING) {
+            throw new IllegalStateException("거절 가능한 상태가 아닙니다.");
+        }
+        this.status = ReservationStatus.REJECTED;
+        this.decidedAt = LocalDateTime.now();
+        // TODO(다음 PR): 캐시 환불 → member.refundCache(totalPrice)
+    }
+
+    public void markCompleted() {
+        if (status != ReservationStatus.CONFIRMED) {
+            throw new IllegalStateException("완료 처리 가능한 상태가 아닙니다.");
+        }
+        this.status = ReservationStatus.COMPLETED;
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/entity/ReservationStatus.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/entity/ReservationStatus.java
@@ -1,0 +1,19 @@
+package com.pickkasso.pickkasso.user.entity;
+
+public enum ReservationStatus {
+    PENDING("승인 대기"),
+    CONFIRMED("예약 확정"),
+    COMPLETED("촬영 완료"),
+    REJECTED("작가 거절"),
+    CANCELED("사용자 취소");
+
+    private final String label;
+
+    ReservationStatus(String label) {
+        this.label = label;
+    }
+
+    public String label() {
+        return label;
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/repository/ReservationRepository.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/repository/ReservationRepository.java
@@ -69,4 +69,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             where r.id = :id
             """)
     Optional<Reservation> findByIdWithDetails(@Param("id") Long id);
+
+    List<Reservation> findByStatusAndScheduledAtBefore(ReservationStatus status, LocalDateTime before);
 }

--- a/src/main/java/com/pickkasso/pickkasso/user/repository/ReservationRepository.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/repository/ReservationRepository.java
@@ -1,0 +1,53 @@
+package com.pickkasso.pickkasso.user.repository;
+
+import com.pickkasso.pickkasso.user.entity.Reservation;
+import com.pickkasso.pickkasso.user.entity.ReservationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    @Query("""
+            select r from Reservation r
+              join fetch r.member m
+              join fetch r.item i
+            where r.photographer.id = :photographerId
+              and r.status = :status
+            order by r.scheduledAt asc
+            """)
+    List<Reservation> findPendingByPhotographer(
+            @Param("photographerId") Long photographerId,
+            @Param("status") ReservationStatus status);
+
+    @Query("""
+            select r from Reservation r
+              join fetch r.member m
+              join fetch r.item i
+            where r.photographer.id = :photographerId
+              and r.scheduledAt >= :from
+              and r.scheduledAt < :to
+              and r.status in :statuses
+            order by r.scheduledAt asc
+            """)
+    List<Reservation> findInRange(
+            @Param("photographerId") Long photographerId,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to,
+            @Param("statuses") Collection<ReservationStatus> statuses);
+
+    long countByPhotographerIdAndStatusAndScheduledAtBetween(
+            Long photographerId, ReservationStatus status,
+            LocalDateTime from, LocalDateTime to);
+
+    long countByPhotographerIdAndStatus(Long photographerId, ReservationStatus status);
+
+    long countByPhotographerId(Long photographerId);
+
+    Optional<Reservation> findByIdAndPhotographerId(Long id, Long photographerId);
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/repository/ReservationRepository.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/repository/ReservationRepository.java
@@ -59,4 +59,14 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     long countByPhotographerId(Long photographerId);
 
     Optional<Reservation> findByIdAndPhotographerId(Long id, Long photographerId);
+
+    @Query("""
+            select r from Reservation r
+              join fetch r.member m
+              join fetch r.item i
+              join fetch i.tag t
+              join fetch i.photographer p
+            where r.id = :id
+            """)
+    Optional<Reservation> findByIdWithDetails(@Param("id") Long id);
 }

--- a/src/main/java/com/pickkasso/pickkasso/user/repository/ReservationRepository.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/repository/ReservationRepository.java
@@ -41,6 +41,15 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             @Param("to") LocalDateTime to,
             @Param("statuses") Collection<ReservationStatus> statuses);
 
+    @Query("""
+            select r from Reservation r
+              join fetch r.member m
+              join fetch r.item i
+            where r.photographer.id = :photographerId
+            order by r.scheduledAt desc
+            """)
+    List<Reservation> findAllByPhotographerIdForManagement(@Param("photographerId") Long photographerId);
+
     long countByPhotographerIdAndStatusAndScheduledAtBetween(
             Long photographerId, ReservationStatus status,
             LocalDateTime from, LocalDateTime to);

--- a/src/main/java/com/pickkasso/pickkasso/user/service/PhotographerReservationService.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/service/PhotographerReservationService.java
@@ -56,19 +56,24 @@ public class PhotographerReservationService {
     }
 
     @Transactional(readOnly = true)
-    public WeeklyCalendarDto getWeeklyCalendar(Long photographerId) {
-        LocalDate today = LocalDate.now();
-        int shift = today.getDayOfWeek().getValue() % 7; // 일=0, 월=1, ..., 토=6
-        LocalDate weekStart = today.minusDays(shift);
-        LocalDate weekEnd = weekStart.plusDays(7);
+    public LocalDate normalizeWeekStart(LocalDate weekStart) {
+        LocalDate baseDate = weekStart != null ? weekStart : LocalDate.now();
+        int shift = baseDate.getDayOfWeek().getValue() % 7; // 일=0, 월=1, ..., 토=6
+        return baseDate.minusDays(shift);
+    }
+
+    @Transactional(readOnly = true)
+    public WeeklyCalendarDto getWeeklyCalendar(Long photographerId, LocalDate weekStart) {
+        LocalDate normalizedWeekStart = normalizeWeekStart(weekStart);
+        LocalDate weekEnd = normalizedWeekStart.plusDays(7);
 
         List<Reservation> reservations = reservationRepository.findInRange(
                 photographerId,
-                weekStart.atStartOfDay(),
+                normalizedWeekStart.atStartOfDay(),
                 weekEnd.atStartOfDay(),
                 List.of(ReservationStatus.CONFIRMED));
 
-        return WeeklyCalendarDto.of(weekStart, reservations);
+        return WeeklyCalendarDto.of(normalizedWeekStart, reservations);
     }
 
     public void approve(Long photographerId, Long reservationId) {

--- a/src/main/java/com/pickkasso/pickkasso/user/service/PhotographerReservationService.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/service/PhotographerReservationService.java
@@ -34,7 +34,7 @@ public class PhotographerReservationService {
         long pendingCount = reservationRepository.countByPhotographerIdAndStatus(
                 photographerId, ReservationStatus.PENDING);
 
-        return new DashboardSummaryDto(todayCount, pendingCount);
+        return new DashboardSummaryDto(todayCount, pendingCount, 0L);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/pickkasso/pickkasso/user/service/PhotographerReservationService.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/service/PhotographerReservationService.java
@@ -75,7 +75,7 @@ public class PhotographerReservationService {
                 photographerId,
                 normalizedWeekStart.atStartOfDay(),
                 weekEnd.atStartOfDay(),
-                List.of(ReservationStatus.CONFIRMED));
+                List.of(ReservationStatus.CONFIRMED, ReservationStatus.COMPLETED));
 
         return WeeklyCalendarDto.of(normalizedWeekStart, reservations);
     }

--- a/src/main/java/com/pickkasso/pickkasso/user/service/PhotographerReservationService.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/service/PhotographerReservationService.java
@@ -10,12 +10,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class PhotographerReservationService {
+    public static final String FILTER_ALL = "ALL";
+    public static final String FILTER_CLOSED = "CLOSED";
 
     private final ReservationRepository reservationRepository;
 
@@ -76,6 +80,78 @@ public class PhotographerReservationService {
         return WeeklyCalendarDto.of(normalizedWeekStart, reservations);
     }
 
+    @Transactional(readOnly = true)
+    public ReservationManagementSummaryDto getManagementSummary(Long photographerId) {
+        List<Reservation> reservations = reservationRepository.findAllByPhotographerIdForManagement(photographerId);
+        LocalDate today = LocalDate.now();
+        LocalDate weekStart = normalizeWeekStart(today);
+        LocalDate weekEnd = weekStart.plusDays(7);
+
+        long totalCount = reservations.size();
+        long pendingCount = countByStatus(reservations, ReservationStatus.PENDING);
+        long confirmedCountThisWeek = reservations.stream()
+                .filter(r -> r.getStatus() == ReservationStatus.CONFIRMED)
+                .filter(r -> !r.getScheduledAt().toLocalDate().isBefore(weekStart) && r.getScheduledAt().toLocalDate().isBefore(weekEnd))
+                .count();
+        long finalizedCount = reservations.stream()
+                .filter(r -> r.getStatus() == ReservationStatus.COMPLETED
+                        || r.getStatus() == ReservationStatus.REJECTED
+                        || r.getStatus() == ReservationStatus.CANCELED)
+                .count();
+        long completedCount = countByStatus(reservations, ReservationStatus.COMPLETED);
+        int completionRate = finalizedCount == 0 ? 0 : (int) Math.round((completedCount * 100.0) / finalizedCount);
+        long urgentPendingCount = reservations.stream()
+                .filter(r -> r.getStatus() == ReservationStatus.PENDING)
+                .filter(r -> !r.getRequestedAt().toLocalDate().isAfter(today))
+                .count();
+        long todayShootCount = reservations.stream()
+                .filter(r -> r.getStatus() == ReservationStatus.CONFIRMED)
+                .filter(r -> r.getScheduledAt().toLocalDate().equals(today))
+                .count();
+        long expectedWeekRevenue = reservations.stream()
+                .filter(r -> r.getStatus() == ReservationStatus.CONFIRMED || r.getStatus() == ReservationStatus.COMPLETED)
+                .filter(r -> !r.getScheduledAt().toLocalDate().isBefore(weekStart) && r.getScheduledAt().toLocalDate().isBefore(weekEnd))
+                .mapToLong(Reservation::getTotalPrice)
+                .sum();
+
+        return new ReservationManagementSummaryDto(
+                totalCount,
+                pendingCount,
+                confirmedCountThisWeek,
+                completionRate,
+                urgentPendingCount,
+                todayShootCount,
+                expectedWeekRevenue
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<ReservationManagementItemDto> getManagementReservations(Long photographerId, String statusFilter, String keyword) {
+        String normalizedStatusFilter = normalizeStatusFilter(statusFilter);
+        String normalizedKeyword = keyword == null ? "" : keyword.trim().toLowerCase(Locale.KOREA);
+
+        return reservationRepository.findAllByPhotographerIdForManagement(photographerId).stream()
+                .filter(reservation -> matchesStatusFilter(reservation, normalizedStatusFilter))
+                .filter(reservation -> matchesKeyword(reservation, normalizedKeyword))
+                .sorted(managementComparator())
+                .map(ReservationManagementItemDto::of)
+                .toList();
+    }
+
+    public String normalizeStatusFilter(String statusFilter) {
+        if (statusFilter == null || statusFilter.isBlank()) {
+            return FILTER_ALL;
+        }
+
+        return switch (statusFilter.trim().toUpperCase(Locale.ROOT)) {
+            case "PENDING" -> ReservationStatus.PENDING.name();
+            case "CONFIRMED" -> ReservationStatus.CONFIRMED.name();
+            case "COMPLETED" -> ReservationStatus.COMPLETED.name();
+            case "REJECTED", "CANCELED", "CLOSED" -> FILTER_CLOSED;
+            default -> FILTER_ALL;
+        };
+    }
+
     public void approve(Long photographerId, Long reservationId) {
         Reservation reservation = reservationRepository
                 .findByIdAndPhotographerId(reservationId, photographerId)
@@ -88,5 +164,64 @@ public class PhotographerReservationService {
                 .findByIdAndPhotographerId(reservationId, photographerId)
                 .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다."));
         reservation.reject();
+    }
+
+    private long countByStatus(List<Reservation> reservations, ReservationStatus status) {
+        return reservations.stream()
+                .filter(r -> r.getStatus() == status)
+                .count();
+    }
+
+    private boolean matchesStatusFilter(Reservation reservation, String statusFilter) {
+        if (FILTER_ALL.equals(statusFilter)) {
+            return true;
+        }
+        if (FILTER_CLOSED.equals(statusFilter)) {
+            return reservation.getStatus() == ReservationStatus.REJECTED
+                    || reservation.getStatus() == ReservationStatus.CANCELED;
+        }
+        return reservation.getStatus().name().equals(statusFilter);
+    }
+
+    private boolean matchesKeyword(Reservation reservation, String normalizedKeyword) {
+        if (normalizedKeyword.isBlank()) {
+            return true;
+        }
+
+        return containsIgnoreCase(reservation.getMember().getName(), normalizedKeyword)
+                || containsIgnoreCase(reservation.getItem().getName(), normalizedKeyword)
+                || containsIgnoreCase(reservation.getAddress(), normalizedKeyword);
+    }
+
+    private boolean containsIgnoreCase(String source, String normalizedKeyword) {
+        return source != null && source.toLowerCase(Locale.KOREA).contains(normalizedKeyword);
+    }
+
+    private Comparator<Reservation> managementComparator() {
+        return Comparator
+                .comparingInt((Reservation reservation) -> statusPriority(reservation.getStatus()))
+                .thenComparing((left, right) -> compareWithinStatus(left, right));
+    }
+
+    private int compareWithinStatus(Reservation left, Reservation right) {
+        boolean finalized = isFinalized(left.getStatus()) && isFinalized(right.getStatus());
+        return finalized
+                ? right.getScheduledAt().compareTo(left.getScheduledAt())
+                : left.getScheduledAt().compareTo(right.getScheduledAt());
+    }
+
+    private boolean isFinalized(ReservationStatus status) {
+        return status == ReservationStatus.COMPLETED
+                || status == ReservationStatus.REJECTED
+                || status == ReservationStatus.CANCELED;
+    }
+
+    private int statusPriority(ReservationStatus status) {
+        return switch (status) {
+            case PENDING -> 0;
+            case CONFIRMED -> 1;
+            case COMPLETED -> 2;
+            case REJECTED, CANCELED -> 3;
+        };
     }
 }

--- a/src/main/java/com/pickkasso/pickkasso/user/service/PhotographerReservationService.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/service/PhotographerReservationService.java
@@ -1,0 +1,87 @@
+package com.pickkasso.pickkasso.user.service;
+
+import com.pickkasso.pickkasso.user.dto.photographer.*;
+import com.pickkasso.pickkasso.user.entity.Reservation;
+import com.pickkasso.pickkasso.user.entity.ReservationStatus;
+import com.pickkasso.pickkasso.user.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PhotographerReservationService {
+
+    private final ReservationRepository reservationRepository;
+
+    @Transactional(readOnly = true)
+    public DashboardSummaryDto getSummary(Long photographerId) {
+        LocalDate today = LocalDate.now();
+        LocalDateTime dayStart = today.atStartOfDay();
+        LocalDateTime dayEnd = today.plusDays(1).atStartOfDay();
+
+        long todayCount = reservationRepository.countByPhotographerIdAndStatusAndScheduledAtBetween(
+                photographerId, ReservationStatus.CONFIRMED, dayStart, dayEnd);
+        long pendingCount = reservationRepository.countByPhotographerIdAndStatus(
+                photographerId, ReservationStatus.PENDING);
+
+        return new DashboardSummaryDto(todayCount, pendingCount);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PendingReservationDto> getPendingList(Long photographerId) {
+        return reservationRepository
+                .findPendingByPhotographer(photographerId, ReservationStatus.PENDING)
+                .stream()
+                .map(PendingReservationDto::of)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TodayScheduleDto> getTodaySchedule(Long photographerId) {
+        LocalDate today = LocalDate.now();
+        return reservationRepository
+                .findInRange(photographerId,
+                        today.atStartOfDay(),
+                        today.plusDays(1).atStartOfDay(),
+                        List.of(ReservationStatus.CONFIRMED))
+                .stream()
+                .map(TodayScheduleDto::of)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public WeeklyCalendarDto getWeeklyCalendar(Long photographerId) {
+        LocalDate today = LocalDate.now();
+        int shift = today.getDayOfWeek().getValue() % 7; // 일=0, 월=1, ..., 토=6
+        LocalDate weekStart = today.minusDays(shift);
+        LocalDate weekEnd = weekStart.plusDays(7);
+
+        List<Reservation> reservations = reservationRepository.findInRange(
+                photographerId,
+                weekStart.atStartOfDay(),
+                weekEnd.atStartOfDay(),
+                List.of(ReservationStatus.CONFIRMED));
+
+        return WeeklyCalendarDto.of(weekStart, reservations);
+    }
+
+    public void approve(Long photographerId, Long reservationId) {
+        Reservation reservation = reservationRepository
+                .findByIdAndPhotographerId(reservationId, photographerId)
+                .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다."));
+        reservation.approve();
+    }
+
+    public void reject(Long photographerId, Long reservationId) {
+        Reservation reservation = reservationRepository
+                .findByIdAndPhotographerId(reservationId, photographerId)
+                .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다."));
+        reservation.reject();
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/service/PhotographerReservationService.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/service/PhotographerReservationService.java
@@ -34,7 +34,7 @@ public class PhotographerReservationService {
         long pendingCount = reservationRepository.countByPhotographerIdAndStatus(
                 photographerId, ReservationStatus.PENDING);
 
-        return new DashboardSummaryDto(todayCount, pendingCount, 0L);
+        return new DashboardSummaryDto(todayCount, pendingCount, 0L, 0L);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/pickkasso/pickkasso/user/service/UserReservationService.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/service/UserReservationService.java
@@ -1,0 +1,56 @@
+package com.pickkasso.pickkasso.user.service;
+
+import com.pickkasso.pickkasso.item.entity.Plan;
+import com.pickkasso.pickkasso.item.repository.PlanRepository;
+import com.pickkasso.pickkasso.user.dto.ReservationCreateRequest;
+import com.pickkasso.pickkasso.user.entity.Member;
+import com.pickkasso.pickkasso.user.entity.Reservation;
+import com.pickkasso.pickkasso.user.repository.MemberRepository;
+import com.pickkasso.pickkasso.user.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+public class UserReservationService {
+
+    private final ReservationRepository reservationRepository;
+    private final MemberRepository memberRepository;
+    private final PlanRepository planRepository;
+
+    @Transactional
+    public Long createReservation(Long memberId, ReservationCreateRequest req) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        Plan plan = planRepository.findByIdWithItemAndPhotographer(req.getPlanId())
+                .orElseThrow(() -> new IllegalArgumentException("패키지를 찾을 수 없습니다."));
+
+        LocalDate date = LocalDate.parse(req.getScheduledDate(), DateTimeFormatter.ISO_LOCAL_DATE);
+        LocalDateTime scheduledAt = LocalDateTime.of(date, LocalTime.of(req.getScheduledHour(), 0));
+
+        String fullAddress = req.getAddress() != null ? req.getAddress().trim() : "";
+        if (req.getDetailAddress() != null && !req.getDetailAddress().isBlank()) {
+            fullAddress = fullAddress + " " + req.getDetailAddress().trim();
+        }
+
+        Reservation reservation = Reservation.create(
+                member,
+                plan.getItem().getPhotographer(),
+                plan.getItem(),
+                scheduledAt,
+                plan.getShootingDuration() * 60,
+                fullAddress,
+                plan.getPrice(),
+                req.getMemo()
+        );
+
+        return reservationRepository.save(reservation).getId();
+    }
+}

--- a/src/main/resources/templates/fragments/photographer-sidebar.html
+++ b/src/main/resources/templates/fragments/photographer-sidebar.html
@@ -46,8 +46,8 @@
       </svg>
       후기 관리
     </a>
-    <!-- 수익 정산 (Mockup) -->
-    <a th:href="@{'/photographer/' + ${userId} + '/dashboard'}"
+    <!-- 수익 정산 -->
+    <a th:href="@{'/photographer/' + ${userId} + '/settlement'}"
        th:classappend="${activeTab == 'settlement'} ? 'bg-[#EEF2FB] text-[#1D3CFF] font-semibold' : 'text-[#444] hover:bg-[#EEF2FB] hover:text-[#1D3CFF]'"
        class="flex items-center gap-2.5 text-sm px-3 py-2.5 rounded-lg transition-colors no-underline">
       <svg class="w-[18px] h-[18px]" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/main/resources/templates/fragments/photographer-sidebar.html
+++ b/src/main/resources/templates/fragments/photographer-sidebar.html
@@ -38,7 +38,7 @@
             th:text="${summary != null ? summary.pendingCount : 0}">2</span>
     </a>
     <!-- 후기 관리 (Mockup) -->
-    <a th:href="@{'/photographer/' + ${userId} + '/dashboard'}"
+    <a th:href="@{'/photographer/' + ${userId} + '/reviews'}"
        th:classappend="${activeTab == 'reviews'} ? 'bg-[#EEF2FB] text-[#1D3CFF] font-semibold' : 'text-[#444] hover:bg-[#EEF2FB] hover:text-[#1D3CFF]'"
        class="flex items-center gap-2.5 text-sm px-3 py-2.5 rounded-lg transition-colors no-underline">
       <svg class="w-[18px] h-[18px]" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/main/resources/templates/fragments/photographer-sidebar.html
+++ b/src/main/resources/templates/fragments/photographer-sidebar.html
@@ -27,14 +27,15 @@
       대시보드
     </a>
     <!-- 예약 관리 (Mockup) -->
-    <a th:href="@{'/photographer/' + ${userId} + '/dashboard'}"
+    <a th:href="@{'/photographer/' + ${userId} + '/reservations'}"
        th:classappend="${activeTab == 'reservations'} ? 'bg-[#EEF2FB] text-[#1D3CFF] font-semibold' : 'text-[#444] hover:bg-[#EEF2FB] hover:text-[#1D3CFF]'"
        class="flex items-center gap-2.5 text-sm px-3 py-2.5 rounded-lg transition-colors no-underline">
       <svg class="w-[18px] h-[18px]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
       </svg>
       예약 관리
-      <span class="ml-auto bg-[#1D3CFF] text-white text-[10px] font-bold rounded-full px-1.5 py-0.5 min-w-[18px] text-center">2</span>
+      <span class="ml-auto bg-[#1D3CFF] text-white text-[10px] font-bold rounded-full px-1.5 py-0.5 min-w-[18px] text-center"
+            th:text="${summary != null ? summary.pendingCount : 0}">2</span>
     </a>
     <!-- 후기 관리 (Mockup) -->
     <a th:href="@{'/photographer/' + ${userId} + '/dashboard'}"

--- a/src/main/resources/templates/photographer/dashboard.html
+++ b/src/main/resources/templates/photographer/dashboard.html
@@ -65,6 +65,13 @@
             .cal-event.green { background: #EEFBF3; color: #22C55E; border-left-color: #22C55E; }
             .cal-event.sky { background: #E6F7FF; color: #0097FF; border-left-color: #0097FF; }
             .cal-event.purple { background: #F3EEFB; color: #7C3AED; border-left-color: #7C3AED; }
+            .cal-event.gray {
+                background: #F3F4F6;
+                color: #4B5563;
+                border-left-color: #6B7280;
+                border: 1px solid #9CA3AF;
+                box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5);
+            }
         </style>
         <script>
             (() => {
@@ -226,7 +233,8 @@
                         </div>
                     </div>
                     <div class="text-2xl font-extrabold text-[#1A1A1A]"><span th:text="${summary.pendingCount}">0</span><span class="text-sm font-medium ml-0.5">건</span></div>
-                    <div class="mt-2 text-[11px] text-[#FF6B2B] font-bold">즉시 처리 필요</div>
+                    <div th:if="${summary.pendingCount > 0}" class="mt-2 text-[11px] text-[#FF6B2B] font-bold">즉시 처리 필요</div>
+                    <div th:unless="${summary.pendingCount > 0}" class="mt-2 text-[11px] text-[#888]">대기 중인 요청 없음</div>
                 </div>
                 <div class="bg-white border border-[#CCC] rounded-2xl p-5">
                     <div class="flex items-center justify-between mb-2.5">
@@ -267,7 +275,8 @@
                             <svg class="w-4 h-4 text-[#1D3CFF]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
                             주간 예약 현황
                         </div>
-                        <a href="#" class="text-[11px] font-bold text-[#0097FF] hover:opacity-70 transition-opacity no-underline flex items-center gap-0.5">
+                        <a th:href="@{/photographer/{pid}/reservations(pid=${photographer.id})}"
+                           class="text-[11px] font-bold text-[#0097FF] hover:opacity-70 transition-opacity no-underline flex items-center gap-0.5">
                             전체 보기
                             <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
                         </a>

--- a/src/main/resources/templates/photographer/dashboard.html
+++ b/src/main/resources/templates/photographer/dashboard.html
@@ -243,10 +243,8 @@
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
                         </div>
                     </div>
-                    <div class="text-xl font-extrabold text-[#1A1A1A]">520,000<span class="text-sm font-medium ml-0.5">C</span></div>
-                    <div class="mt-2 text-[11px] text-[#888] flex items-center gap-1.5">
-                        <span class="inline-flex items-center gap-0.5 bg-[#EAF7EE] text-[#1A8E40] font-bold rounded px-1.5 py-0.5">▲ 18%</span> 전월 대비
-                    </div>
+                    <div class="text-xl font-extrabold text-[#1A1A1A]"><span th:text="${#numbers.formatInteger(summary.monthlyRevenue, 1, 'COMMA')}">0</span><span class="text-sm font-medium ml-0.5">C</span></div>
+                    <div class="mt-2 text-[11px] text-[#888]">이번 달 누적</div>
                 </div>
                 <div class="bg-white border border-[#CCC] rounded-2xl p-5">
                     <div class="flex items-center justify-between mb-2.5">

--- a/src/main/resources/templates/photographer/dashboard.html
+++ b/src/main/resources/templates/photographer/dashboard.html
@@ -325,8 +325,9 @@
                                         <div th:if="${event != null}"
                                              th:class="'cal-event ' + ${event.colorClass} + ' top-1'"
                                              th:style="'height:' + (${event.rowSpanHours} * 64 - 6) + 'px'">
-                                            <div class="font-bold truncate" th:text="${event.title}">제목</div>
-                                            <div class="opacity-80 truncate" th:text="${event.subtitle}">고객 · 시간</div>
+                                            <div class="font-bold leading-tight break-all" th:text="${event.title}">제목</div>
+                                            <div class="opacity-80 leading-tight break-all" th:text="${event.subtitle}">고객</div>
+                                            <div class="opacity-60 leading-tight" th:text="${event.timeLabel}">시간</div>
                                         </div>
                                     </div>
                                 </th:block>

--- a/src/main/resources/templates/photographer/dashboard.html
+++ b/src/main/resources/templates/photographer/dashboard.html
@@ -66,6 +66,115 @@
             .cal-event.sky { background: #E6F7FF; color: #0097FF; border-left-color: #0097FF; }
             .cal-event.purple { background: #F3EEFB; color: #7C3AED; border-left-color: #7C3AED; }
         </style>
+        <script>
+            (() => {
+                function buildFragmentUrl(baseUrl, weekStart) {
+                    const url = new URL(baseUrl, window.location.origin);
+                    if (weekStart) {
+                        url.searchParams.set('weekStart', weekStart);
+                    } else {
+                        url.searchParams.delete('weekStart');
+                    }
+                    return url.toString();
+                }
+
+                function syncCurrentWeekInputs(weekStart) {
+                    document.querySelectorAll('.js-current-week-start').forEach((input) => {
+                        input.value = weekStart || '';
+                    });
+                }
+
+                async function loadWeeklyCalendar(fragmentUrl, pageUrl, pushState) {
+                    const currentCard = document.getElementById('weekly-calendar-card');
+                    if (!currentCard) return;
+
+                    currentCard.classList.add('opacity-60', 'pointer-events-none');
+
+                    try {
+                        const response = await fetch(fragmentUrl, {
+                            headers: {
+                                'X-Requested-With': 'XMLHttpRequest'
+                            }
+                        });
+
+                        if (!response.ok) {
+                            throw new Error('failed to load weekly calendar');
+                        }
+
+                        const html = (await response.text()).trim();
+                        const template = document.createElement('template');
+                        template.innerHTML = html;
+                        const nextCard = template.content.firstElementChild;
+
+                        if (!nextCard) {
+                            throw new Error('empty weekly calendar fragment');
+                        }
+
+                        currentCard.replaceWith(nextCard);
+                        syncCurrentWeekInputs(nextCard.dataset.weekStart || '');
+
+                        if (pushState) {
+                            history.pushState({ pageUrl, fragmentUrl }, '', pageUrl);
+                        }
+                    } catch (error) {
+                        window.location.href = pageUrl;
+                    }
+                }
+
+                function getCurrentCard() {
+                    return document.getElementById('weekly-calendar-card');
+                }
+
+                function replaceStateFromDom() {
+                    const currentCard = getCurrentCard();
+                    if (!currentCard) return;
+
+                    const currentUrl = new URL(window.location.href);
+                    const weekStart = currentUrl.searchParams.get('weekStart');
+                    history.replaceState({
+                        pageUrl: currentUrl.toString(),
+                        fragmentUrl: buildFragmentUrl(currentCard.dataset.fragmentUrl, weekStart)
+                    }, '', currentUrl.toString());
+                    syncCurrentWeekInputs(currentCard.dataset.weekStart || '');
+                }
+
+                document.addEventListener('click', (event) => {
+                    const link = event.target.closest('[data-weekly-calendar-nav]');
+                    if (!link) return;
+
+                    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey || link.target === '_blank') {
+                        return;
+                    }
+
+                    event.preventDefault();
+                    loadWeeklyCalendar(link.dataset.fragmentHref, link.href, true);
+                });
+
+                window.addEventListener('popstate', (event) => {
+                    const currentCard = getCurrentCard();
+                    if (!currentCard) return;
+
+                    if (event.state?.fragmentUrl && event.state?.pageUrl) {
+                        loadWeeklyCalendar(event.state.fragmentUrl, event.state.pageUrl, false);
+                        return;
+                    }
+
+                    const currentUrl = new URL(window.location.href);
+                    const weekStart = currentUrl.searchParams.get('weekStart');
+                    loadWeeklyCalendar(
+                        buildFragmentUrl(currentCard.dataset.fragmentUrl, weekStart),
+                        currentUrl.toString(),
+                        false
+                    );
+                });
+
+                if (document.readyState === 'loading') {
+                    document.addEventListener('DOMContentLoaded', replaceStateFromDom, { once: true });
+                } else {
+                    replaceStateFromDom();
+                }
+            })();
+        </script>
     </th:block>
 </head>
 <body>
@@ -147,7 +256,12 @@
             <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
                 
                 <!-- 주간 예약 현황 -->
-                <div class="xl:col-span-2 bg-white border border-[#CCC] rounded-2xl overflow-hidden flex flex-col">
+                <div id="weekly-calendar-card"
+                     th:fragment="weeklyCalendarCard"
+                     class="xl:col-span-2 bg-white border border-[#CCC] rounded-2xl overflow-hidden flex flex-col"
+                     th:attr="data-week-start=${weekly.weekStartIso},
+                              data-dashboard-url=@{/photographer/{pid}/dashboard(pid=${photographer.id})},
+                              data-fragment-url=@{/photographer/{pid}/dashboard/weekly-calendar(pid=${photographer.id})}">
                     <div class="p-5 border-b border-[#EEE] flex items-center justify-between">
                         <div class="flex items-center gap-2 font-bold text-[#1A1A1A]">
                             <svg class="w-4 h-4 text-[#1D3CFF]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
@@ -162,11 +276,21 @@
                     <div class="p-4 bg-[#F9FAFC] flex items-center justify-between border-b border-[#EEE]">
                         <span class="text-xs font-bold text-[#444]" th:text="${weekly.rangeLabel}">2026년 4월 6일 – 12일</span>
                         <div class="flex items-center gap-2">
-                            <button class="bg-white border border-[#CCC] rounded-lg px-2.5 py-1 text-[11px] font-bold text-[#444] hover:border-[#1D3CFF] transition-colors">오늘</button>
+                            <a th:href="@{/photographer/{pid}/dashboard(pid=${photographer.id}, weekStart=${weekly.todayWeekStartIso})}"
+                               th:attr="data-fragment-href=@{/photographer/{pid}/dashboard/weekly-calendar(pid=${photographer.id}, weekStart=${weekly.todayWeekStartIso})}"
+                               data-weekly-calendar-nav
+                               class="bg-white border rounded-lg px-2.5 py-1 text-[11px] font-bold transition-colors no-underline"
+                               th:classappend="${weekly.currentWeek()} ? ' border-[#1D3CFF] text-[#1D3CFF] bg-[#EEF2FB] pointer-events-none' : ' border-[#CCC] text-[#444] hover:border-[#1D3CFF]'">오늘</a>
                             <div class="flex items-center border border-[#CCC] bg-white rounded-lg">
-                                <button class="p-1 px-1.5 hover:text-[#1D3CFF] transition-colors"><svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg></button>
+                                <a th:href="@{/photographer/{pid}/dashboard(pid=${photographer.id}, weekStart=${weekly.prevWeekStartIso})}"
+                                   th:attr="data-fragment-href=@{/photographer/{pid}/dashboard/weekly-calendar(pid=${photographer.id}, weekStart=${weekly.prevWeekStartIso})}"
+                                   data-weekly-calendar-nav
+                                   class="p-1 px-1.5 text-[#444] hover:text-[#1D3CFF] transition-colors no-underline"><svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg></a>
                                 <div class="w-[1px] h-3 bg-[#CCC]"></div>
-                                <button class="p-1 px-1.5 hover:text-[#1D3CFF] transition-colors"><svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg></button>
+                                <a th:href="@{/photographer/{pid}/dashboard(pid=${photographer.id}, weekStart=${weekly.nextWeekStartIso})}"
+                                   th:attr="data-fragment-href=@{/photographer/{pid}/dashboard/weekly-calendar(pid=${photographer.id}, weekStart=${weekly.nextWeekStartIso})}"
+                                   data-weekly-calendar-nav
+                                   class="p-1 px-1.5 text-[#444] hover:text-[#1D3CFF] transition-colors no-underline"><svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg></a>
                             </div>
                         </div>
                     </div>
@@ -263,11 +387,13 @@
                                     <form th:action="@{/photographer/{pid}/reservations/{rid}/accept(pid=${photographer.id},rid=${p.reservationId})}"
                                           method="post" class="inline">
                                         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                                        <input type="hidden" name="weekStart" th:value="${weekly.weekStartIso}" class="js-current-week-start" />
                                         <button type="submit" class="bg-white border border-[#1D3CFF] text-[#1D3CFF] text-[10px] font-bold px-2 py-1 rounded-md hover:bg-[#1D3CFF] hover:text-white transition-colors">수락</button>
                                     </form>
                                     <form th:action="@{/photographer/{pid}/reservations/{rid}/reject(pid=${photographer.id},rid=${p.reservationId})}"
                                           method="post" class="inline">
                                         <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                                        <input type="hidden" name="weekStart" th:value="${weekly.weekStartIso}" class="js-current-week-start" />
                                         <button type="submit" class="bg-white border border-[#CCC] text-[#888] text-[10px] font-bold px-2 py-1 rounded-md hover:border-[#888] hover:text-[#444] transition-colors">거절</button>
                                     </form>
                                 </div>

--- a/src/main/resources/templates/photographer/dashboard.html
+++ b/src/main/resources/templates/photographer/dashboard.html
@@ -84,7 +84,11 @@
                 <div class="relative z-10">
                     <p class="text-[13px] opacity-80 mb-1.5" th:text="${#calendars.format(#calendars.createNow(), 'M월 d일 EEEE')} + ' ☀️ 오늘도 좋은 하루 되세요!'">4월 10일 목요일 ☀️ 오늘도 좋은 하루 되세요!</p>
                     <h2 class="text-2xl font-extrabold mb-1">안녕하세요, <span th:text="${photographer.name}">김민준</span> 작가님 👋</h2>
-                    <p class="text-[13px] opacity-70">오늘 예약 2건 · 승인 대기 2건 · 출금 가능 382,500C</p>
+                    <p class="text-[13px] opacity-70">
+                        오늘 예약 <span th:text="${summary.todayCount}">0</span>건 ·
+                        승인 대기 <span th:text="${summary.pendingCount}">0</span>건 ·
+                        출금 가능 382,500C
+                    </p>
                 </div>
 <!-- 배경 장식 원 -->
                 <div class="absolute -right-10 -top-10 w-52 h-52 bg-white/5 rounded-full"></div>
@@ -100,7 +104,7 @@
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/></svg>
                         </div>
                     </div>
-                    <div class="text-2xl font-extrabold text-[#1A1A1A]">2<span class="text-sm font-medium ml-0.5">건</span></div>
+                    <div class="text-2xl font-extrabold text-[#1A1A1A]"><span th:text="${summary.todayCount}">0</span><span class="text-sm font-medium ml-0.5">건</span></div>
                     <div class="mt-2 text-[11px] text-[#888] flex items-center gap-1.5">
                         <span class="inline-flex items-center gap-0.5 bg-[#EAF7EE] text-[#1A8E40] font-bold rounded px-1.5 py-0.5">▲ 1</span> 전일 대비
                     </div>
@@ -112,7 +116,7 @@
                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
                         </div>
                     </div>
-                    <div class="text-2xl font-extrabold text-[#1A1A1A]">2<span class="text-sm font-medium ml-0.5">건</span></div>
+                    <div class="text-2xl font-extrabold text-[#1A1A1A]"><span th:text="${summary.pendingCount}">0</span><span class="text-sm font-medium ml-0.5">건</span></div>
                     <div class="mt-2 text-[11px] text-[#FF6B2B] font-bold">즉시 처리 필요</div>
                 </div>
                 <div class="bg-white border border-[#CCC] rounded-2xl p-5">
@@ -156,7 +160,7 @@
                     </div>
                     
                     <div class="p-4 bg-[#F9FAFC] flex items-center justify-between border-b border-[#EEE]">
-                        <span class="text-xs font-bold text-[#444]">2026년 4월 6일 – 12일</span>
+                        <span class="text-xs font-bold text-[#444]" th:text="${weekly.rangeLabel}">2026년 4월 6일 – 12일</span>
                         <div class="flex items-center gap-2">
                             <button class="bg-white border border-[#CCC] rounded-lg px-2.5 py-1 text-[11px] font-bold text-[#444] hover:border-[#1D3CFF] transition-colors">오늘</button>
                             <div class="flex items-center border border-[#CCC] bg-white rounded-lg">
@@ -170,169 +174,33 @@
                     <div class="w-full flex-1 min-h-0 overflow-y-auto">
                     <div class="cal-grid">
                         <div class="cal-corner"></div>
+                        <th:block th:each="day : ${weekly.dayHeaders}">
                         <div class="cal-day-header">
-                            <div class="text-[10px] font-semibold text-[#888] mb-1 tracking-wide">일</div>
-                            <div class="text-[18px] font-extrabold text-[#E03535] w-[34px] h-[34px] flex items-center justify-center mx-auto">6</div>
+                            <div class="text-[10px] font-semibold mb-1 tracking-wide"
+                                 th:classappend="${day.isToday()} ? 'text-[#1D3CFF]' : (${day.isSunday()} ? 'text-[#E03535]' : (${day.isSaturday()} ? 'text-[#0097FF]' : 'text-[#888]'))"
+                                 th:text="${day.labelKor}">일</div>
+                            <div class="text-[18px] font-extrabold w-[34px] h-[34px] flex items-center justify-center mx-auto"
+                                 th:classappend="${day.isToday()} ? 'text-white bg-[#1D3CFF] rounded-full' : (${day.isSunday()} ? 'text-[#E03535]' : (${day.isSaturday()} ? 'text-[#0097FF]' : 'text-[#1A1A1A]'))"
+                                 th:text="${day.dayOfMonth}">6</div>
                         </div>
-                        <div class="cal-day-header">
-                            <div class="text-[10px] font-semibold text-[#888] mb-1 tracking-wide">월</div>
-                            <div class="text-[18px] font-extrabold text-[#1A1A1A] w-[34px] h-[34px] flex items-center justify-center mx-auto">7</div>
-                        </div>
-                        <div class="cal-day-header">
-                            <div class="text-[10px] font-semibold text-[#888] mb-1 tracking-wide">화</div>
-                            <div class="text-[18px] font-extrabold text-[#1A1A1A] w-[34px] h-[34px] flex items-center justify-center mx-auto">8</div>
-                        </div>
-                        <div class="cal-day-header">
-                            <div class="text-[10px] font-semibold text-[#888] mb-1 tracking-wide">수</div>
-                            <div class="text-[18px] font-extrabold text-[#1A1A1A] w-[34px] h-[34px] flex items-center justify-center mx-auto">9</div>
-                        </div>
-                        <div class="cal-day-header">
-                            <div class="text-[10px] font-semibold text-[#1D3CFF] mb-1 tracking-wide">목</div>
-                            <div class="text-[18px] font-extrabold text-white bg-[#1D3CFF] w-[34px] h-[34px] rounded-full flex items-center justify-center mx-auto">10</div>
-                        </div>
-                        <div class="cal-day-header">
-                            <div class="text-[10px] font-semibold text-[#888] mb-1 tracking-wide">금</div>
-                            <div class="text-[18px] font-extrabold text-[#1A1A1A] w-[34px] h-[34px] flex items-center justify-center mx-auto">11</div>
-                        </div>
-                        <div class="cal-day-header">
-                            <div class="text-[10px] font-semibold text-[#888] mb-1 tracking-wide">토</div>
-                            <div class="text-[18px] font-extrabold text-[#0097FF] w-[34px] h-[34px] flex items-center justify-center mx-auto">12</div>
-                        </div>
+                        </th:block>
 
-                        <!-- 09:00 -->
-                        <div class="cal-time-col">09:00</div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell">
-                            <div class="cal-event blue top-1 h-14">
-                                <div class="font-bold truncate">데이트 스냅</div>
-                                <div class="opacity-80 truncate">이수빈 · 09:00</div>
-                            </div>
-                        </div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell bg-[#FAFBFF]"></div>
-                        <div class="cal-cell">
-                            <div class="cal-event orange top-1 h-14">
-                                <div class="font-bold truncate">증명사진</div>
-                                <div class="opacity-80 truncate">정우진 · 09:00</div>
-                            </div>
-                        </div>
-                        <div class="cal-cell"></div>
-
-                        <!-- 10:00 -->
-                        <div class="cal-time-col">10:00</div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell">
-                            <div class="cal-event green top-1 h-28">
-                                <div class="font-bold truncate">졸업사진</div>
-                                <div class="opacity-80 truncate">김하늘 · 10:00–12:00</div>
-                            </div>
-                        </div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell bg-[#FAFBFF]">
-                            <div class="cal-event blue top-1 h-14">
-                                <div class="font-bold truncate">프로필 촬영</div>
-                                <div class="opacity-80 truncate">박준서 · 10:00</div>
-                            </div>
-                        </div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-
-                        <!-- 11:00 -->
-                        <div class="cal-time-col">11:00</div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell bg-[#FAFBFF]"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell">
-                            <div class="cal-event sky top-1 h-14">
-                                <div class="font-bold truncate">가족사진</div>
-                                <div class="opacity-80 truncate">최민영 · 11:00</div>
-                            </div>
-                        </div>
-
-                        <!-- 12:00 -->
-                        <div class="cal-time-col">12:00</div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell bg-[#FAFBFF]"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-
-                        <!-- 13:00 -->
-                        <div class="cal-time-col">13:00</div>
-                        <div class="cal-cell">
-                            <div class="cal-event purple top-1 h-14">
-                                <div class="font-bold truncate">웨딩 스냅</div>
-                                <div class="opacity-80 truncate">강지우 · 13:00</div>
-                            </div>
-                        </div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell bg-[#FAFBFF]">
-                            <div class="cal-event green top-1 h-[122px]">
-                                <div class="font-bold truncate">데이트 스냅</div>
-                                <div class="opacity-80 truncate">이수빈 · 13:00–15:00</div>
-                            </div>
-                        </div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-
-                        <!-- 14:00 -->
-                        <div class="cal-time-col">14:00</div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell bg-[#FAFBFF]"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-
-                        <!-- 15:00 -->
-                        <div class="cal-time-col">15:00</div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell bg-[#FAFBFF]"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-
-                        <!-- 16:00 -->
-                        <div class="cal-time-col">16:00</div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell bg-[#FAFBFF]"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-
-                        <!-- 17:00 -->
-                        <div class="cal-time-col">17:00</div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell bg-[#FAFBFF]"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-
-                        <!-- 18:00 -->
-                        <div class="cal-time-col">18:00</div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell bg-[#FAFBFF]"></div>
-                        <div class="cal-cell"></div>
-                        <div class="cal-cell"></div>
+                        <!-- 시간 그리드 (동적) -->
+                        <th:block th:each="hour : ${weekly.hourSlots}">
+                            <div class="cal-time-col" th:text="${#numbers.formatInteger(hour, 2) + ':00'}">09:00</div>
+                            <th:block th:each="dayIdx : ${#numbers.sequence(0, 6)}">
+                                <th:block th:with="key=|${dayIdx}-${hour}|, event=${weekly.eventByCellKey.get(key)}">
+                                    <div th:class="${dayIdx == 6} ? 'cal-cell bg-[#FAFBFF]' : 'cal-cell'">
+                                        <div th:if="${event != null}"
+                                             th:class="'cal-event ' + ${event.colorClass} + ' top-1'"
+                                             th:style="'height:' + (${event.rowSpanHours} * 64 - 6) + 'px'">
+                                            <div class="font-bold truncate" th:text="${event.title}">제목</div>
+                                            <div class="opacity-80 truncate" th:text="${event.subtitle}">고객 · 시간</div>
+                                        </div>
+                                    </div>
+                                </th:block>
+                            </th:block>
+                        </th:block>
                     </div>
                     </div>
                 </div>
@@ -349,35 +217,26 @@
                             </div>
                             <span class="text-[11px] font-bold text-[#888]" th:text="${#calendars.format(#calendars.createNow(), 'M월 d일 (E)')}">4월 10일 (목)</span>
                         </div>
-                        <div class="space-y-6">
-                            <div class="flex gap-4">
+                        <div th:if="${todaySchedule != null and !#lists.isEmpty(todaySchedule)}" class="space-y-6">
+                            <div class="flex gap-4" th:each="s, st : ${todaySchedule}">
                                 <div class="flex flex-col items-center">
-                                    <span class="text-xs font-bold text-[#1A1A1A]">10:00</span>
-                                    <span class="text-[10px] text-[#888]">AM</span>
+                                    <span class="text-xs font-bold text-[#1A1A1A]" th:text="${s.timeLabel}">10:00</span>
+                                    <span class="text-[10px] text-[#888]" th:text="${s.ampm}">AM</span>
                                 </div>
                                 <div class="flex flex-col items-center pt-1.5">
-                                    <div class="w-2 h-2 rounded-full bg-[#1D3CFF] mb-1"></div>
-                                    <div class="w-[1.5px] h-10 bg-[#EEE]"></div>
+                                    <div class="w-2 h-2 rounded-full mb-1" th:style="'background:' + ${s.dotColorHex}"></div>
+                                    <div th:unless="${st.last}" class="w-[1.5px] h-10 bg-[#EEE]"></div>
                                 </div>
                                 <div class="flex-1">
-                                    <div class="text-sm font-bold text-[#1A1A1A]">프로필 촬영 (개인)</div>
-                                    <div class="text-[11px] text-[#888] mt-0.5">📍 서울 스튜디오 · 박준서 고객</div>
-                                </div>
-                            </div>
-                            <div class="flex gap-4">
-                                <div class="flex flex-col items-center">
-                                    <span class="text-xs font-bold text-[#1A1A1A]">13:00</span>
-                                    <span class="text-[10px] text-[#888]">PM</span>
-                                </div>
-                                <div class="flex flex-col items-center pt-1.5">
-                                    <div class="w-2 h-2 rounded-full bg-[#22C55E]"></div>
-                                </div>
-                                <div class="flex-1">
-                                    <div class="text-sm font-bold text-[#1A1A1A]">데이트 스냅 (2인)</div>
-                                    <div class="text-[11px] text-[#888] mt-0.5">📍 홍대 / 연남동 · 이수빈 고객</div>
+                                    <div class="text-sm font-bold text-[#1A1A1A]" th:text="${s.itemName}">서비스명</div>
+                                    <div class="text-[11px] text-[#888] mt-0.5">
+                                        📍 <span th:text="${s.address}">장소</span> · <span th:text="${s.memberName}">고객</span> 고객
+                                    </div>
                                 </div>
                             </div>
                         </div>
+                        <div th:unless="${todaySchedule != null and !#lists.isEmpty(todaySchedule)}"
+                             class="text-sm text-[#888] py-6 text-center">오늘 예정된 촬영이 없습니다.</div>
                     </div>
 
                     <!-- 승인 대기 -->
@@ -386,33 +245,36 @@
                             <div class="flex items-center gap-2 font-bold text-[#1A1A1A]">
                                 <svg class="w-4 h-4 text-[#FF6B2B]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
                                 승인 대기
-                                <span class="bg-[#FF6B2B] text-white text-[10px] font-bold rounded-full px-1.5 py-0.5 min-w-[18px] text-center">2</span>
+                                <span class="bg-[#FF6B2B] text-white text-[10px] font-bold rounded-full px-1.5 py-0.5 min-w-[18px] text-center"
+                                      th:text="${summary.pendingCount}">0</span>
                             </div>
                         </div>
-                        <div class="space-y-4">
-                            <div class="flex items-center gap-3">
-                                <div class="w-9 h-9 rounded-full bg-[#D3DEF2] text-[#888] flex items-center justify-center text-sm font-semibold">정</div>
+                        <div th:if="${pendingList != null and !#lists.isEmpty(pendingList)}" class="space-y-4">
+                            <div class="flex items-center gap-3" th:each="p : ${pendingList}">
+                                <div class="w-9 h-9 rounded-full bg-[#D3DEF2] text-[#888] flex items-center justify-center text-sm font-semibold"
+                                     th:text="${p.memberInitial}">정</div>
                                 <div class="flex-1 min-w-0">
-                                    <div class="text-xs font-bold text-[#1A1A1A] truncate">정우진</div>
-                                    <div class="text-[10px] text-[#888] truncate">증명사진 · 4/11(금) 09:00</div>
+                                    <div class="text-xs font-bold text-[#1A1A1A] truncate" th:text="${p.memberName}">이름</div>
+                                    <div class="text-[10px] text-[#888] truncate">
+                                        <span th:text="${p.itemName}">서비스</span> · <span th:text="${p.scheduledLabel}">날짜</span>
+                                    </div>
                                 </div>
                                 <div class="flex gap-1 shrink-0">
-                                    <button class="bg-white border border-[#1D3CFF] text-[#1D3CFF] text-[10px] font-bold px-2 py-1 rounded-md hover:bg-[#1D3CFF] hover:text-white transition-colors">수락</button>
-                                    <button class="bg-white border border-[#CCC] text-[#888] text-[10px] font-bold px-2 py-1 rounded-md hover:border-[#888] hover:text-[#444] transition-colors">거절</button>
-                                </div>
-                            </div>
-                            <div class="flex items-center gap-3">
-                                <div class="w-9 h-9 rounded-full bg-[#D3DEF2] text-[#888] flex items-center justify-center text-sm font-semibold">강</div>
-                                <div class="flex-1 min-w-0">
-                                    <div class="text-xs font-bold text-[#1A1A1A] truncate">강지우</div>
-                                    <div class="text-[10px] text-[#888] truncate">웨딩 스냅 · 4/12(토) 14:00</div>
-                                </div>
-                                <div class="flex gap-1 shrink-0">
-                                    <button class="bg-white border border-[#1D3CFF] text-[#1D3CFF] text-[10px] font-bold px-2 py-1 rounded-md hover:bg-[#1D3CFF] hover:text-white transition-colors">수락</button>
-                                    <button class="bg-white border border-[#CCC] text-[#888] text-[10px] font-bold px-2 py-1 rounded-md hover:border-[#888] hover:text-[#444] transition-colors">거절</button>
+                                    <form th:action="@{/photographer/{pid}/reservations/{rid}/accept(pid=${photographer.id},rid=${p.reservationId})}"
+                                          method="post" class="inline">
+                                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                                        <button type="submit" class="bg-white border border-[#1D3CFF] text-[#1D3CFF] text-[10px] font-bold px-2 py-1 rounded-md hover:bg-[#1D3CFF] hover:text-white transition-colors">수락</button>
+                                    </form>
+                                    <form th:action="@{/photographer/{pid}/reservations/{rid}/reject(pid=${photographer.id},rid=${p.reservationId})}"
+                                          method="post" class="inline">
+                                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                                        <button type="submit" class="bg-white border border-[#CCC] text-[#888] text-[10px] font-bold px-2 py-1 rounded-md hover:border-[#888] hover:text-[#444] transition-colors">거절</button>
+                                    </form>
                                 </div>
                             </div>
                         </div>
+                        <div th:unless="${pendingList != null and !#lists.isEmpty(pendingList)}"
+                             class="text-sm text-[#888] py-4 text-center">승인 대기 중인 예약이 없습니다.</div>
                     </div>
 
                     <!-- 프로필 완성도 -->

--- a/src/main/resources/templates/photographer/dashboard.html
+++ b/src/main/resources/templates/photographer/dashboard.html
@@ -72,6 +72,20 @@
                 border: 1px solid #9CA3AF;
                 box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.5);
             }
+            @keyframes floatA {
+                0%   { transform: translate(0px, 0px) scale(1); }
+                33%  { transform: translate(-65px, 35px) scale(1.08); }
+                66%  { transform: translate(-30px, -45px) scale(0.93); }
+                100% { transform: translate(0px, 0px) scale(1); }
+            }
+            @keyframes floatB {
+                0%   { transform: translate(0px, 0px) scale(1); }
+                33%  { transform: translate(30px, -55px) scale(0.92); }
+                66%  { transform: translate(-55px, -25px) scale(1.07); }
+                100% { transform: translate(0px, 0px) scale(1); }
+            }
+            .banner-circle-a { animation: floatA 22s ease-in-out infinite; }
+            .banner-circle-b { animation: floatB 32s ease-in-out infinite; }
         </style>
         <script>
             (() => {
@@ -203,12 +217,12 @@
                     <p class="text-[13px] opacity-70">
                         오늘 예약 <span th:text="${summary.todayCount}">0</span>건 ·
                         승인 대기 <span th:text="${summary.pendingCount}">0</span>건 ·
-                        출금 가능 382,500C
+                        출금 가능 <span th:text="${#numbers.formatInteger(summary.withdrawableAmount, 1, 'COMMA')}">0</span>C
                     </p>
                 </div>
 <!-- 배경 장식 원 -->
-                <div class="absolute -right-10 -top-10 w-52 h-52 bg-white/5 rounded-full"></div>
-                <div class="absolute right-20 -bottom-12 w-40 h-40 bg-white/5 rounded-full"></div>
+                <div class="banner-circle-a absolute -right-10 -top-10 w-44 h-44 bg-white/5 rounded-full"></div>
+                <div class="banner-circle-b absolute right-20 -bottom-12 w-36 h-36 bg-white/5 rounded-full"></div>
             </div>
 
             <!-- KPI Row -->

--- a/src/main/resources/templates/photographer/reservations.html
+++ b/src/main/resources/templates/photographer/reservations.html
@@ -16,6 +16,12 @@
                 font-size: 11px;
                 font-weight: 700;
                 color: #444;
+                text-decoration: none;
+                transition: border-color 0.15s, color 0.15s, background 0.15s;
+            }
+            .reservation-chip:hover {
+                border-color: #1D3CFF;
+                color: #1D3CFF;
             }
             .reservation-chip.active {
                 border-color: #1D3CFF;
@@ -48,18 +54,14 @@
                 background: #F5F5F5;
                 color: #888;
             }
-            .mini-dot {
-                width: 8px;
-                height: 8px;
-                border-radius: 9999px;
-                flex-shrink: 0;
-            }
         </style>
     </th:block>
 </head>
 <body>
 
-<main th:fragment="content" class="max-w-[1216px] mx-auto px-6 py-8">
+<main th:fragment="content"
+      th:with="hasReservations=${reservationItems != null and !#lists.isEmpty(reservationItems)}"
+      class="max-w-[1216px] mx-auto px-6 py-8">
     <div class="flex flex-col lg:flex-row gap-8 items-start">
 
         <th:block th:replace="~{fragments/photographer-sidebar :: sidebar}" />
@@ -74,26 +76,26 @@
                             <span th:text="${photographer.name}">김민준</span> 작가님의 전체 예약 현황
                         </h1>
                         <p class="text-[13px] text-white/75 mt-3 leading-relaxed">
-                            예약 요청부터 촬영 완료까지 한 화면에서 흐름을 관리할 수 있도록 정리한 운영 페이지입니다.
+                            승인 대기, 예약 확정, 촬영 완료 흐름을 한 화면에서 보고 바로 대응할 수 있도록 정리했습니다.
                         </p>
                     </div>
 
                     <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 xl:min-w-[520px]">
                         <div class="rounded-2xl bg-white/10 border border-white/10 px-4 py-4 backdrop-blur-sm">
                             <p class="text-[11px] text-white/70 mb-1">전체 예약</p>
-                            <p class="text-2xl font-black">28<span class="text-sm font-semibold ml-1">건</span></p>
+                            <p class="text-2xl font-black"><span th:text="${reservationManagementSummary.totalCount}">0</span><span class="text-sm font-semibold ml-1">건</span></p>
                         </div>
                         <div class="rounded-2xl bg-white/10 border border-white/10 px-4 py-4 backdrop-blur-sm">
                             <p class="text-[11px] text-white/70 mb-1">승인 대기</p>
-                            <p class="text-2xl font-black" th:text="${summary.pendingCount} + '건'">2건</p>
+                            <p class="text-2xl font-black"><span th:text="${reservationManagementSummary.pendingCount}">0</span><span class="text-sm font-semibold ml-1">건</span></p>
                         </div>
                         <div class="rounded-2xl bg-white/10 border border-white/10 px-4 py-4 backdrop-blur-sm">
                             <p class="text-[11px] text-white/70 mb-1">이번 주 확정</p>
-                            <p class="text-2xl font-black">11<span class="text-sm font-semibold ml-1">건</span></p>
+                            <p class="text-2xl font-black"><span th:text="${reservationManagementSummary.confirmedCountThisWeek}">0</span><span class="text-sm font-semibold ml-1">건</span></p>
                         </div>
                         <div class="rounded-2xl bg-white/10 border border-white/10 px-4 py-4 backdrop-blur-sm">
                             <p class="text-[11px] text-white/70 mb-1">완료 전환율</p>
-                            <p class="text-2xl font-black">92<span class="text-sm font-semibold ml-1">%</span></p>
+                            <p class="text-2xl font-black"><span th:text="${reservationManagementSummary.completionRate}">0</span><span class="text-sm font-semibold ml-1">%</span></p>
                         </div>
                     </div>
                 </div>
@@ -106,26 +108,42 @@
                 <div class="flex flex-col gap-4">
                     <div class="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
                         <div class="flex flex-wrap gap-2">
-                            <button type="button" class="reservation-chip active">전체</button>
-                            <button type="button" class="reservation-chip">승인 대기</button>
-                            <button type="button" class="reservation-chip">예약 확정</button>
-                            <button type="button" class="reservation-chip">촬영 완료</button>
-                            <button type="button" class="reservation-chip">거절 / 취소</button>
+                            <a th:href="@{/photographer/{pid}/reservations(pid=${photographer.id}, status='ALL', keyword=${keyword})}"
+                               th:classappend="${selectedStatus == 'ALL'} ? ' active' : ''"
+                               class="reservation-chip">전체</a>
+                            <a th:href="@{/photographer/{pid}/reservations(pid=${photographer.id}, status='PENDING', keyword=${keyword})}"
+                               th:classappend="${selectedStatus == 'PENDING'} ? ' active' : ''"
+                               class="reservation-chip">승인 대기</a>
+                            <a th:href="@{/photographer/{pid}/reservations(pid=${photographer.id}, status='CONFIRMED', keyword=${keyword})}"
+                               th:classappend="${selectedStatus == 'CONFIRMED'} ? ' active' : ''"
+                               class="reservation-chip">예약 확정</a>
+                            <a th:href="@{/photographer/{pid}/reservations(pid=${photographer.id}, status='COMPLETED', keyword=${keyword})}"
+                               th:classappend="${selectedStatus == 'COMPLETED'} ? ' active' : ''"
+                               class="reservation-chip">촬영 완료</a>
+                            <a th:href="@{/photographer/{pid}/reservations(pid=${photographer.id}, status='CLOSED', keyword=${keyword})}"
+                               th:classappend="${selectedStatus == 'CLOSED'} ? ' active' : ''"
+                               class="reservation-chip">거절 / 취소</a>
                         </div>
-                        <div class="flex flex-col sm:flex-row gap-2">
+
+                        <form method="get"
+                              th:action="@{/photographer/{pid}/reservations(pid=${photographer.id})}"
+                              class="flex flex-col sm:flex-row gap-2">
+                            <input type="hidden" name="status" th:value="${selectedStatus}" />
                             <div class="relative">
                                 <input type="text"
-                                       placeholder="고객명, 서비스명으로 검색"
-                                       class="w-full sm:w-[240px] rounded-xl border border-[#CCC] bg-[#F9FAFC] pl-10 pr-4 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] focus:outline-none focus:border-[#1D3CFF] focus:ring-1 focus:ring-[#1D3CFF]">
+                                       name="keyword"
+                                       th:value="${keyword}"
+                                       placeholder="고객명, 서비스명, 장소 검색"
+                                       class="w-full sm:w-[280px] rounded-xl border border-[#CCC] bg-[#F9FAFC] pl-10 pr-4 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] focus:outline-none focus:border-[#1D3CFF] focus:ring-1 focus:ring-[#1D3CFF]">
                                 <svg class="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-[#888]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 110-15 7.5 7.5 0 010 15z" />
                                 </svg>
                             </div>
-                            <button type="button"
+                            <button type="submit"
                                     class="rounded-xl border border-[#CCC] bg-white px-4 py-2.5 text-sm font-bold text-[#444] hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">
-                                이번 달
+                                검색
                             </button>
-                        </div>
+                        </form>
                     </div>
 
                     <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
@@ -133,8 +151,8 @@
                             <p class="text-[11px] font-bold text-[#888] mb-2">오늘 우선 처리</p>
                             <div class="flex items-center justify-between">
                                 <div>
-                                    <p class="text-lg font-black text-[#1A1A1A]">2건</p>
-                                    <p class="text-[12px] text-[#888] mt-1">30분 안에 응답 권장</p>
+                                    <p class="text-lg font-black text-[#1A1A1A]"><span th:text="${reservationManagementSummary.urgentPendingCount}">0</span>건</p>
+                                    <p class="text-[12px] text-[#888] mt-1">승인 대기 요청 점검</p>
                                 </div>
                                 <div class="w-11 h-11 rounded-2xl bg-[#FFF4EE] text-[#FF6B2B] flex items-center justify-center">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -147,8 +165,8 @@
                             <p class="text-[11px] font-bold text-[#888] mb-2">오늘 촬영</p>
                             <div class="flex items-center justify-between">
                                 <div>
-                                    <p class="text-lg font-black text-[#1A1A1A]">3건</p>
-                                    <p class="text-[12px] text-[#888] mt-1">오전 10시부터 시작</p>
+                                    <p class="text-lg font-black text-[#1A1A1A]"><span th:text="${reservationManagementSummary.todayShootCount}">0</span>건</p>
+                                    <p class="text-[12px] text-[#888] mt-1">확정 예약 기준</p>
                                 </div>
                                 <div class="w-11 h-11 rounded-2xl bg-[#EEF2FB] text-[#1D3CFF] flex items-center justify-center">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -161,8 +179,8 @@
                             <p class="text-[11px] font-bold text-[#888] mb-2">이번 주 매출 예상</p>
                             <div class="flex items-center justify-between">
                                 <div>
-                                    <p class="text-lg font-black text-[#1A1A1A]">830,000C</p>
-                                    <p class="text-[12px] text-[#888] mt-1">확정 예약 기준</p>
+                                    <p class="text-lg font-black text-[#1A1A1A]"><span th:text="${#numbers.formatInteger(reservationManagementSummary.expectedWeekRevenue, 0, 'COMMA')}">0</span>C</p>
+                                    <p class="text-[12px] text-[#888] mt-1">확정/완료 예약 기준</p>
                                 </div>
                                 <div class="w-11 h-11 rounded-2xl bg-[#E6F7FF] text-[#0097FF] flex items-center justify-center">
                                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -180,130 +198,94 @@
                     <div class="px-5 py-4 border-b border-[#EEE] flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                         <div>
                             <h2 class="text-lg font-black text-[#1A1A1A]">전체 예약 리스트</h2>
-                            <p class="text-[12px] text-[#888] mt-1">승인 대기부터 완료 건까지 시간순으로 관리할 수 있습니다.</p>
+                            <p class="text-[12px] text-[#888] mt-1"
+                               th:text="${hasReservations ? '총 ' + #lists.size(reservationItems) + '건의 예약을 표시 중입니다.' : '조건에 맞는 예약이 없습니다.'}">
+                                총 0건의 예약을 표시 중입니다.
+                            </p>
                         </div>
-                        <div class="inline-flex items-center gap-1 rounded-full bg-[#F9FAFC] border border-[#CCC] px-1.5 py-1 text-[11px] font-bold text-[#888]">
-                            <button type="button" class="rounded-full bg-white border border-[#CCC] px-3 py-1 text-[#1A1A1A]">리스트</button>
-                            <button type="button" class="rounded-full px-3 py-1 hover:text-[#1D3CFF] transition-colors">보드</button>
+                        <div class="text-[12px] text-[#888]">
+                            상태 우선순위: 승인 대기 → 예약 확정 → 촬영 완료 → 거절 / 취소
                         </div>
                     </div>
 
-                    <div class="divide-y divide-[#EEE]">
-                        <article class="px-5 py-5 hover:bg-[#FCFCFD] transition-colors">
+                    <div th:if="${hasReservations}" class="divide-y divide-[#EEE]">
+                        <article th:each="reservation : ${reservationItems}"
+                                 class="px-5 py-5 hover:bg-[#FCFCFD] transition-colors">
                             <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                                 <div class="min-w-0">
                                     <div class="flex flex-wrap items-center gap-2 mb-3">
-                                        <span class="status-pill pending">승인 대기</span>
-                                        <span class="text-[11px] font-bold text-[#FF6B2B]">오늘 안에 응답 필요</span>
+                                        <span class="status-pill"
+                                              th:classappend="${reservation.statusClassName}"
+                                              th:text="${reservation.statusLabel}">승인 대기</span>
+                                        <span class="text-[11px] font-bold"
+                                              th:classappend="${reservation.statusHintColorClass}"
+                                              th:text="${reservation.statusHint}">빠른 응답 필요</span>
                                     </div>
+
                                     <div class="flex items-start gap-3">
-                                        <div class="w-12 h-12 rounded-2xl bg-[#D3DEF2] text-[#1D3CFF] flex items-center justify-center text-lg font-black shrink-0">정</div>
+                                        <div class="w-12 h-12 rounded-2xl bg-[#D3DEF2] text-[#1D3CFF] flex items-center justify-center text-lg font-black shrink-0"
+                                             th:text="${reservation.memberInitial}">정</div>
                                         <div class="min-w-0">
-                                            <h3 class="text-[18px] font-black text-[#1A1A1A] leading-tight">정우진 고객 · 증명사진</h3>
-                                            <p class="text-[13px] text-[#888] mt-1">4월 25일 (토) 09:00 · 강남 스튜디오 · 50,000C</p>
-                                            <p class="text-[13px] text-[#444] mt-3 leading-relaxed">
-                                                취업용 증명사진 촬영 요청. 자연스러운 보정 위주로 희망하며 오전 시간대 촬영을 선호한다고 남겼습니다.
+                                            <h3 class="text-[18px] font-black text-[#1A1A1A] leading-tight">
+                                                <span th:text="${reservation.memberName}">정우진</span> 고객 ·
+                                                <span th:text="${reservation.itemName}">증명사진</span>
+                                            </h3>
+                                            <p class="text-[13px] text-[#888] mt-1">
+                                                <span th:text="${reservation.scheduleLabel}">4월 25일 (토) 09:00 - 10:00</span>
+                                                · <span th:text="${reservation.address}">강남 스튜디오</span>
+                                                · <span th:text="${reservation.priceLabel}">50,000C</span>
+                                            </p>
+                                            <p class="text-[13px] text-[#444] mt-3 leading-relaxed whitespace-pre-line"
+                                               th:text="${reservation.memo}">
+                                                예약 메모
                                             </p>
                                         </div>
                                     </div>
                                 </div>
-                                <div class="flex flex-col sm:flex-row lg:flex-col gap-2 lg:min-w-[138px]">
-                                    <button type="button" class="rounded-xl border border-[#1D3CFF] bg-white px-4 py-2.5 text-sm font-bold text-[#1D3CFF] hover:bg-[#1D3CFF] hover:text-white transition-colors">수락</button>
-                                    <button type="button" class="rounded-xl border border-[#CCC] bg-white px-4 py-2.5 text-sm font-bold text-[#666] hover:border-[#888] hover:text-[#1A1A1A] transition-colors">거절</button>
-                                </div>
-                            </div>
-                        </article>
 
-                        <article class="px-5 py-5 hover:bg-[#FCFCFD] transition-colors">
-                            <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                                <div class="min-w-0">
-                                    <div class="flex flex-wrap items-center gap-2 mb-3">
-                                        <span class="status-pill confirmed">예약 확정</span>
-                                        <span class="text-[11px] font-bold text-[#1D3CFF]">D-1 리마인드 발송 예정</span>
-                                    </div>
-                                    <div class="flex items-start gap-3">
-                                        <div class="w-12 h-12 rounded-2xl bg-[#E6F7FF] text-[#0097FF] flex items-center justify-center text-lg font-black shrink-0">이</div>
-                                        <div class="min-w-0">
-                                            <h3 class="text-[18px] font-black text-[#1A1A1A] leading-tight">이수빈 고객 · 데이트 스냅</h3>
-                                            <p class="text-[13px] text-[#888] mt-1">4월 26일 (일) 13:00 - 15:00 · 홍대 / 연남동 · 150,000C</p>
-                                            <div class="mt-3 flex flex-wrap gap-2">
-                                                <span class="inline-flex items-center gap-1 rounded-full bg-[#F9FAFC] border border-[#CCC] px-3 py-1 text-[11px] font-semibold text-[#444]">
-                                                    <span class="mini-dot bg-[#1D3CFF]"></span> 커플 촬영
-                                                </span>
-                                                <span class="inline-flex items-center gap-1 rounded-full bg-[#F9FAFC] border border-[#CCC] px-3 py-1 text-[11px] font-semibold text-[#444]">
-                                                    <span class="mini-dot bg-[#22C55E]"></span> 보정본 10컷
-                                                </span>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
                                 <div class="flex flex-col sm:flex-row lg:flex-col gap-2 lg:min-w-[138px]">
-                                    <button type="button" class="rounded-xl border border-[#CCC] bg-white px-4 py-2.5 text-sm font-bold text-[#444] hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">상세 보기</button>
-                                    <button type="button" class="rounded-xl border border-[#CCC] bg-[#F9FAFC] px-4 py-2.5 text-sm font-bold text-[#888] hover:border-[#888] hover:text-[#444] transition-colors">일정 변경</button>
-                                </div>
-                            </div>
-                        </article>
-
-                        <article class="px-5 py-5 hover:bg-[#FCFCFD] transition-colors">
-                            <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                                <div class="min-w-0">
-                                    <div class="flex flex-wrap items-center gap-2 mb-3">
-                                        <span class="status-pill completed">촬영 완료</span>
-                                        <span class="text-[11px] font-bold text-[#1A8E40]">정산 대기 중</span>
-                                    </div>
-                                    <div class="flex items-start gap-3">
-                                        <div class="w-12 h-12 rounded-2xl bg-[#EEFBF3] text-[#1A8E40] flex items-center justify-center text-lg font-black shrink-0">김</div>
-                                        <div class="min-w-0">
-                                            <h3 class="text-[18px] font-black text-[#1A1A1A] leading-tight">김하늘 고객 · 졸업사진</h3>
-                                            <p class="text-[13px] text-[#888] mt-1">4월 21일 (화) 10:00 - 12:00 · 광화문 · 180,000C</p>
-                                            <p class="text-[13px] text-[#444] mt-3 leading-relaxed">
-                                                촬영은 정상 종료되었고, 1차 셀렉 가이드를 전달한 상태입니다. 보정본 전달 마감은 4월 28일로 예정되어 있습니다.
-                                            </p>
+                                    <th:block th:if="${reservation.actionable}">
+                                        <form th:action="@{/photographer/{pid}/reservations/{rid}/accept(pid=${photographer.id},rid=${reservation.reservationId})}"
+                                              method="post" class="w-full">
+                                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                                            <input type="hidden" name="redirectTo" value="reservations" />
+                                            <input type="hidden" name="status" th:value="${selectedStatus}" />
+                                            <input type="hidden" name="keyword" th:value="${keyword}" />
+                                            <button type="submit"
+                                                    class="w-full rounded-xl border border-[#1D3CFF] bg-white px-4 py-2.5 text-sm font-bold text-[#1D3CFF] hover:bg-[#1D3CFF] hover:text-white transition-colors">
+                                                수락
+                                            </button>
+                                        </form>
+                                        <form th:action="@{/photographer/{pid}/reservations/{rid}/reject(pid=${photographer.id},rid=${reservation.reservationId})}"
+                                              method="post" class="w-full">
+                                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                                            <input type="hidden" name="redirectTo" value="reservations" />
+                                            <input type="hidden" name="status" th:value="${selectedStatus}" />
+                                            <input type="hidden" name="keyword" th:value="${keyword}" />
+                                            <button type="submit"
+                                                    class="w-full rounded-xl border border-[#CCC] bg-white px-4 py-2.5 text-sm font-bold text-[#666] hover:border-[#888] hover:text-[#1A1A1A] transition-colors">
+                                                거절
+                                            </button>
+                                        </form>
+                                    </th:block>
+                                    <th:block th:unless="${reservation.actionable}">
+                                        <div class="rounded-xl border border-[#EEE] bg-[#F9FAFC] px-4 py-3 text-center">
+                                            <p class="text-[11px] font-bold text-[#888]">현재 상태</p>
+                                            <p class="text-sm font-black text-[#1A1A1A] mt-1" th:text="${reservation.statusLabel}">예약 확정</p>
                                         </div>
-                                    </div>
-                                </div>
-                                <div class="flex flex-col sm:flex-row lg:flex-col gap-2 lg:min-w-[138px]">
-                                    <button type="button" class="rounded-xl border border-[#CCC] bg-white px-4 py-2.5 text-sm font-bold text-[#444] hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">후기 요청</button>
-                                    <button type="button" class="rounded-xl border border-[#CCC] bg-[#F9FAFC] px-4 py-2.5 text-sm font-bold text-[#888] hover:border-[#888] hover:text-[#444] transition-colors">정산 보기</button>
-                                </div>
-                            </div>
-                        </article>
-
-                        <article class="px-5 py-5 hover:bg-[#FCFCFD] transition-colors">
-                            <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                                <div class="min-w-0">
-                                    <div class="flex flex-wrap items-center gap-2 mb-3">
-                                        <span class="status-pill rejected">작가 거절</span>
-                                        <span class="text-[11px] font-bold text-[#888]">응답 완료</span>
-                                    </div>
-                                    <div class="flex items-start gap-3">
-                                        <div class="w-12 h-12 rounded-2xl bg-[#F2F2F2] text-[#888] flex items-center justify-center text-lg font-black shrink-0">강</div>
-                                        <div class="min-w-0">
-                                            <h3 class="text-[18px] font-black text-[#1A1A1A] leading-tight">강지우 고객 · 웨딩 스냅</h3>
-                                            <p class="text-[13px] text-[#888] mt-1">4월 19일 (일) 14:00 · 한강공원 · 200,000C</p>
-                                            <p class="text-[13px] text-[#444] mt-3 leading-relaxed">
-                                                요청 시간대에 이미 기존 촬영이 있어 진행이 어려워 거절한 케이스입니다. 자동 환불 처리 영역이 들어올 자리를 고려해 안내 문구 영역을 확보했습니다.
-                                            </p>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="flex flex-col sm:flex-row lg:flex-col gap-2 lg:min-w-[138px]">
-                                    <button type="button" class="rounded-xl border border-[#CCC] bg-white px-4 py-2.5 text-sm font-bold text-[#444] hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">상세 보기</button>
-                                    <button type="button" class="rounded-xl border border-[#CCC] bg-[#F9FAFC] px-4 py-2.5 text-sm font-bold text-[#888] hover:border-[#888] hover:text-[#444] transition-colors">사유 수정</button>
+                                    </th:block>
                                 </div>
                             </div>
                         </article>
                     </div>
 
-                    <div class="px-5 py-4 border-t border-[#EEE] flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                        <p class="text-[12px] text-[#888]">총 28건 중 1 - 4건 표시</p>
-                        <div class="flex items-center gap-1">
-                            <button type="button" class="w-9 h-9 rounded-lg border border-[#CCC] bg-white text-[#888] hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">‹</button>
-                            <button type="button" class="w-9 h-9 rounded-lg border border-[#1D3CFF] bg-[#EEF2FB] text-[#1D3CFF] font-bold">1</button>
-                            <button type="button" class="w-9 h-9 rounded-lg border border-[#CCC] bg-white text-[#444] font-bold hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">2</button>
-                            <button type="button" class="w-9 h-9 rounded-lg border border-[#CCC] bg-white text-[#444] font-bold hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">3</button>
-                            <button type="button" class="w-9 h-9 rounded-lg border border-[#CCC] bg-white text-[#888] hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">›</button>
-                        </div>
+                    <div th:unless="${hasReservations}"
+                         class="px-8 py-16 text-center">
+                        <div class="text-5xl mb-4">📅</div>
+                        <p class="text-base font-semibold text-[#444] mb-2">조건에 맞는 예약이 아직 없어요.</p>
+                        <p class="text-sm text-[#888]">
+                            필터를 바꾸거나 검색어를 지우면 다른 예약을 확인할 수 있습니다.
+                        </p>
                     </div>
                 </div>
 
@@ -315,62 +297,47 @@
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                                 </svg>
                             </div>
-                            <h2 class="text-base font-black text-[#1A1A1A]">운영 메모</h2>
+                            <h2 class="text-base font-black text-[#1A1A1A]">운영 포인트</h2>
                         </div>
 
                         <div class="space-y-4">
                             <div class="rounded-2xl border border-[#CCC] bg-[#F9FAFC] p-4">
-                                <p class="text-[11px] font-bold text-[#888] mb-2">응답 SLA</p>
-                                <p class="text-[13px] text-[#444] leading-relaxed">승인 대기 예약은 1시간 이내 응답을 기본 목표로 두고, 24시간 이상 미응답 건은 별도 강조로 표시하는 구조를 고려했습니다.</p>
+                                <p class="text-[11px] font-bold text-[#888] mb-2">승인 대기 대응</p>
+                                <p class="text-[13px] text-[#444] leading-relaxed">
+                                    승인 대기 예약은 리스트 최상단에 먼저 노출됩니다. 빠르게 응답할수록 고객 이탈 가능성을 낮출 수 있습니다.
+                                </p>
                             </div>
                             <div class="rounded-2xl border border-[#CCC] bg-[#F9FAFC] p-4">
-                                <p class="text-[11px] font-bold text-[#888] mb-2">후속 확장 포인트</p>
-                                <p class="text-[13px] text-[#444] leading-relaxed">추후 실제 데이터 연결 시 상태 필터, 날짜 범위, 고객 검색, 정렬, 보드/리스트 전환을 자연스럽게 이어 붙일 수 있도록 레이아웃을 잡았습니다.</p>
+                                <p class="text-[11px] font-bold text-[#888] mb-2">검색 범위</p>
+                                <p class="text-[13px] text-[#444] leading-relaxed">
+                                    고객명, 서비스명, 촬영 장소를 기준으로 검색할 수 있도록 연결했습니다.
+                                </p>
                             </div>
                         </div>
                     </section>
 
                     <section class="bg-white border border-[#CCC] rounded-2xl p-5">
                         <div class="flex items-center justify-between mb-4">
-                            <h2 class="text-base font-black text-[#1A1A1A]">오늘 처리 체크</h2>
-                            <span class="text-[11px] font-bold text-[#1D3CFF]">3 / 5 완료</span>
+                            <h2 class="text-base font-black text-[#1A1A1A]">빠른 요약</h2>
+                            <span class="text-[11px] font-bold text-[#1D3CFF]">실시간 기준</span>
                         </div>
 
                         <div class="space-y-3">
-                            <div class="flex items-start gap-3">
-                                <div class="w-5 h-5 rounded-full bg-[#22C55E] text-white flex items-center justify-center text-[10px] font-black mt-0.5">✓</div>
-                                <div>
-                                    <p class="text-sm font-bold text-[#1A1A1A]">오전 촬영 일정 리마인드 전달</p>
-                                    <p class="text-[12px] text-[#888] mt-1">10:00 / 13:00 예약 고객에게 자동 메시지 발송 예정</p>
-                                </div>
+                            <div class="flex items-center justify-between rounded-xl border border-[#EEE] bg-[#F9FAFC] px-4 py-3">
+                                <span class="text-sm text-[#444]">오늘 촬영</span>
+                                <span class="text-sm font-black text-[#1A1A1A]" th:text="${reservationManagementSummary.todayShootCount} + '건'">0건</span>
                             </div>
-                            <div class="flex items-start gap-3">
-                                <div class="w-5 h-5 rounded-full bg-[#22C55E] text-white flex items-center justify-center text-[10px] font-black mt-0.5">✓</div>
-                                <div>
-                                    <p class="text-sm font-bold text-[#1A1A1A]">확정 예약 주소 재확인</p>
-                                    <p class="text-[12px] text-[#888] mt-1">홍대 / 연남동 야외 촬영 동선 메모 업데이트</p>
-                                </div>
+                            <div class="flex items-center justify-between rounded-xl border border-[#EEE] bg-[#F9FAFC] px-4 py-3">
+                                <span class="text-sm text-[#444]">승인 대기</span>
+                                <span class="text-sm font-black text-[#FF6B2B]" th:text="${reservationManagementSummary.pendingCount} + '건'">0건</span>
                             </div>
-                            <div class="flex items-start gap-3">
-                                <div class="w-5 h-5 rounded-full bg-[#22C55E] text-white flex items-center justify-center text-[10px] font-black mt-0.5">✓</div>
-                                <div>
-                                    <p class="text-sm font-bold text-[#1A1A1A]">완료 건 보정본 전달 일정 체크</p>
-                                    <p class="text-[12px] text-[#888] mt-1">졸업사진 보정본 납기 4월 28일</p>
-                                </div>
+                            <div class="flex items-center justify-between rounded-xl border border-[#EEE] bg-[#F9FAFC] px-4 py-3">
+                                <span class="text-sm text-[#444]">이번 주 확정</span>
+                                <span class="text-sm font-black text-[#1D3CFF]" th:text="${reservationManagementSummary.confirmedCountThisWeek} + '건'">0건</span>
                             </div>
-                            <div class="flex items-start gap-3">
-                                <div class="w-5 h-5 rounded-full border-2 border-[#CCC] mt-0.5"></div>
-                                <div>
-                                    <p class="text-sm font-bold text-[#1A1A1A]">승인 대기 2건 응답</p>
-                                    <p class="text-[12px] text-[#888] mt-1">정우진 / 강지우 고객 예약 요청 처리 필요</p>
-                                </div>
-                            </div>
-                            <div class="flex items-start gap-3">
-                                <div class="w-5 h-5 rounded-full border-2 border-[#CCC] mt-0.5"></div>
-                                <div>
-                                    <p class="text-sm font-bold text-[#1A1A1A]">거절 사유 템플릿 정리</p>
-                                    <p class="text-[12px] text-[#888] mt-1">일정 중복 / 촬영 범위 불일치 유형 분리</p>
-                                </div>
+                            <div class="flex items-center justify-between rounded-xl border border-[#EEE] bg-[#F9FAFC] px-4 py-3">
+                                <span class="text-sm text-[#444]">완료 전환율</span>
+                                <span class="text-sm font-black text-[#1A8E40]" th:text="${reservationManagementSummary.completionRate} + '%'">0%</span>
                             </div>
                         </div>
                     </section>

--- a/src/main/resources/templates/photographer/reservations.html
+++ b/src/main/resources/templates/photographer/reservations.html
@@ -54,6 +54,20 @@
                 background: #F5F5F5;
                 color: #888;
             }
+            @keyframes floatA {
+                0%   { transform: translate(0px, 0px) scale(1); }
+                33%  { transform: translate(-65px, 35px) scale(1.08); }
+                66%  { transform: translate(-30px, -45px) scale(0.93); }
+                100% { transform: translate(0px, 0px) scale(1); }
+            }
+            @keyframes floatB {
+                0%   { transform: translate(0px, 0px) scale(1); }
+                33%  { transform: translate(30px, -55px) scale(0.92); }
+                66%  { transform: translate(-55px, -25px) scale(1.07); }
+                100% { transform: translate(0px, 0px) scale(1); }
+            }
+            .banner-circle-a { animation: floatA 22s ease-in-out infinite; }
+            .banner-circle-b { animation: floatB 32s ease-in-out infinite; }
         </style>
     </th:block>
 </head>
@@ -69,7 +83,7 @@
         <div class="flex-1 min-w-0 flex flex-col gap-6">
 
             <section class="relative overflow-hidden rounded-2xl border border-[#1D3CFF]/10 bg-gradient-to-br from-[#1D3CFF] to-[#0097FF] px-7 py-7 text-white">
-                <div class="relative z-10 flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
+                <div class="relative z-10 flex flex-col gap-6 xl:flex-row xl:gap-12 xl:items-end xl:justify-between">
                     <div class="min-w-0">
                         <p class="text-[13px] font-semibold uppercase tracking-[0.22em] text-white/75 mb-2">Reservation Control</p>
                         <h1 class="text-2xl leading-tight font-extrabold whitespace-nowrap">
@@ -100,8 +114,8 @@
                     </div>
                 </div>
 
-                <div class="absolute -right-12 -top-12 h-44 w-44 rounded-full bg-white/10"></div>
-                <div class="absolute right-28 bottom-[-52px] h-36 w-36 rounded-full bg-white/10"></div>
+                <div class="banner-circle-a absolute -right-12 -top-12 h-44 w-44 rounded-full bg-white/10"></div>
+                <div class="banner-circle-b absolute right-28 bottom-[-52px] h-36 w-36 rounded-full bg-white/10"></div>
             </section>
 
             <section class="bg-white border border-[#CCC] rounded-2xl p-5">
@@ -193,7 +207,7 @@
                 </div>
             </section>
 
-            <section class="grid grid-cols-1 2xl:grid-cols-[minmax(0,1fr)_320px] gap-6">
+            <section>
                 <div class="bg-white border border-[#CCC] rounded-2xl overflow-hidden">
                     <div class="px-5 py-4 border-b border-[#EEE] flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                         <div>

--- a/src/main/resources/templates/photographer/reservations.html
+++ b/src/main/resources/templates/photographer/reservations.html
@@ -71,8 +71,8 @@
             <section class="relative overflow-hidden rounded-2xl border border-[#1D3CFF]/10 bg-gradient-to-br from-[#1D3CFF] to-[#0097FF] px-7 py-7 text-white">
                 <div class="relative z-10 flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
                     <div class="min-w-0">
-                        <p class="text-[12px] font-semibold uppercase tracking-[0.22em] text-white/75 mb-2">Reservation Control</p>
-                        <h1 class="text-[30px] leading-tight font-black">
+                        <p class="text-[13px] font-semibold uppercase tracking-[0.22em] text-white/75 mb-2">Reservation Control</p>
+                        <h1 class="text-2xl leading-tight font-extrabold whitespace-nowrap">
                             <span th:text="${photographer.name}">김민준</span> 작가님의 전체 예약 현황
                         </h1>
                         <p class="text-[13px] text-white/75 mt-3 leading-relaxed">

--- a/src/main/resources/templates/photographer/reservations.html
+++ b/src/main/resources/templates/photographer/reservations.html
@@ -1,0 +1,384 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layouts/default :: layout(~{::title}, ~{::headExtra}, ~{::content})}">
+<head>
+    <title>예약 관리 - PICKASSO</title>
+    <th:block th:fragment="headExtra">
+        <style>
+            .reservation-chip {
+                display: inline-flex;
+                align-items: center;
+                gap: 6px;
+                border-radius: 9999px;
+                border: 1px solid #CCC;
+                background: #fff;
+                padding: 6px 12px;
+                font-size: 11px;
+                font-weight: 700;
+                color: #444;
+            }
+            .reservation-chip.active {
+                border-color: #1D3CFF;
+                background: #EEF2FB;
+                color: #1D3CFF;
+            }
+            .status-pill {
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                border-radius: 9999px;
+                padding: 5px 10px;
+                font-size: 11px;
+                font-weight: 700;
+                line-height: 1;
+            }
+            .status-pill.pending {
+                background: #FFF4EE;
+                color: #FF6B2B;
+            }
+            .status-pill.confirmed {
+                background: #EEF2FB;
+                color: #1D3CFF;
+            }
+            .status-pill.completed {
+                background: #EEFBF3;
+                color: #1A8E40;
+            }
+            .status-pill.rejected {
+                background: #F5F5F5;
+                color: #888;
+            }
+            .mini-dot {
+                width: 8px;
+                height: 8px;
+                border-radius: 9999px;
+                flex-shrink: 0;
+            }
+        </style>
+    </th:block>
+</head>
+<body>
+
+<main th:fragment="content" class="max-w-[1216px] mx-auto px-6 py-8">
+    <div class="flex flex-col lg:flex-row gap-8 items-start">
+
+        <th:block th:replace="~{fragments/photographer-sidebar :: sidebar}" />
+
+        <div class="flex-1 min-w-0 flex flex-col gap-6">
+
+            <section class="relative overflow-hidden rounded-2xl border border-[#1D3CFF]/10 bg-gradient-to-br from-[#1D3CFF] to-[#0097FF] px-7 py-7 text-white">
+                <div class="relative z-10 flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
+                    <div class="min-w-0">
+                        <p class="text-[12px] font-semibold uppercase tracking-[0.22em] text-white/75 mb-2">Reservation Control</p>
+                        <h1 class="text-[30px] leading-tight font-black">
+                            <span th:text="${photographer.name}">김민준</span> 작가님의 전체 예약 현황
+                        </h1>
+                        <p class="text-[13px] text-white/75 mt-3 leading-relaxed">
+                            예약 요청부터 촬영 완료까지 한 화면에서 흐름을 관리할 수 있도록 정리한 운영 페이지입니다.
+                        </p>
+                    </div>
+
+                    <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 xl:min-w-[520px]">
+                        <div class="rounded-2xl bg-white/10 border border-white/10 px-4 py-4 backdrop-blur-sm">
+                            <p class="text-[11px] text-white/70 mb-1">전체 예약</p>
+                            <p class="text-2xl font-black">28<span class="text-sm font-semibold ml-1">건</span></p>
+                        </div>
+                        <div class="rounded-2xl bg-white/10 border border-white/10 px-4 py-4 backdrop-blur-sm">
+                            <p class="text-[11px] text-white/70 mb-1">승인 대기</p>
+                            <p class="text-2xl font-black" th:text="${summary.pendingCount} + '건'">2건</p>
+                        </div>
+                        <div class="rounded-2xl bg-white/10 border border-white/10 px-4 py-4 backdrop-blur-sm">
+                            <p class="text-[11px] text-white/70 mb-1">이번 주 확정</p>
+                            <p class="text-2xl font-black">11<span class="text-sm font-semibold ml-1">건</span></p>
+                        </div>
+                        <div class="rounded-2xl bg-white/10 border border-white/10 px-4 py-4 backdrop-blur-sm">
+                            <p class="text-[11px] text-white/70 mb-1">완료 전환율</p>
+                            <p class="text-2xl font-black">92<span class="text-sm font-semibold ml-1">%</span></p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="absolute -right-12 -top-12 h-44 w-44 rounded-full bg-white/10"></div>
+                <div class="absolute right-28 bottom-[-52px] h-36 w-36 rounded-full bg-white/10"></div>
+            </section>
+
+            <section class="bg-white border border-[#CCC] rounded-2xl p-5">
+                <div class="flex flex-col gap-4">
+                    <div class="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+                        <div class="flex flex-wrap gap-2">
+                            <button type="button" class="reservation-chip active">전체</button>
+                            <button type="button" class="reservation-chip">승인 대기</button>
+                            <button type="button" class="reservation-chip">예약 확정</button>
+                            <button type="button" class="reservation-chip">촬영 완료</button>
+                            <button type="button" class="reservation-chip">거절 / 취소</button>
+                        </div>
+                        <div class="flex flex-col sm:flex-row gap-2">
+                            <div class="relative">
+                                <input type="text"
+                                       placeholder="고객명, 서비스명으로 검색"
+                                       class="w-full sm:w-[240px] rounded-xl border border-[#CCC] bg-[#F9FAFC] pl-10 pr-4 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] focus:outline-none focus:border-[#1D3CFF] focus:ring-1 focus:ring-[#1D3CFF]">
+                                <svg class="absolute left-3.5 top-1/2 -translate-y-1/2 w-4 h-4 text-[#888]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 110-15 7.5 7.5 0 010 15z" />
+                                </svg>
+                            </div>
+                            <button type="button"
+                                    class="rounded-xl border border-[#CCC] bg-white px-4 py-2.5 text-sm font-bold text-[#444] hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">
+                                이번 달
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="grid grid-cols-1 md:grid-cols-3 gap-3">
+                        <div class="rounded-2xl border border-[#CCC] bg-[#F9FAFC] px-4 py-4">
+                            <p class="text-[11px] font-bold text-[#888] mb-2">오늘 우선 처리</p>
+                            <div class="flex items-center justify-between">
+                                <div>
+                                    <p class="text-lg font-black text-[#1A1A1A]">2건</p>
+                                    <p class="text-[12px] text-[#888] mt-1">30분 안에 응답 권장</p>
+                                </div>
+                                <div class="w-11 h-11 rounded-2xl bg-[#FFF4EE] text-[#FF6B2B] flex items-center justify-center">
+                                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                    </svg>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="rounded-2xl border border-[#CCC] bg-[#F9FAFC] px-4 py-4">
+                            <p class="text-[11px] font-bold text-[#888] mb-2">오늘 촬영</p>
+                            <div class="flex items-center justify-between">
+                                <div>
+                                    <p class="text-lg font-black text-[#1A1A1A]">3건</p>
+                                    <p class="text-[12px] text-[#888] mt-1">오전 10시부터 시작</p>
+                                </div>
+                                <div class="w-11 h-11 rounded-2xl bg-[#EEF2FB] text-[#1D3CFF] flex items-center justify-center">
+                                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                                    </svg>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="rounded-2xl border border-[#CCC] bg-[#F9FAFC] px-4 py-4">
+                            <p class="text-[11px] font-bold text-[#888] mb-2">이번 주 매출 예상</p>
+                            <div class="flex items-center justify-between">
+                                <div>
+                                    <p class="text-lg font-black text-[#1A1A1A]">830,000C</p>
+                                    <p class="text-[12px] text-[#888] mt-1">확정 예약 기준</p>
+                                </div>
+                                <div class="w-11 h-11 rounded-2xl bg-[#E6F7FF] text-[#0097FF] flex items-center justify-center">
+                                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                    </svg>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="grid grid-cols-1 2xl:grid-cols-[minmax(0,1fr)_320px] gap-6">
+                <div class="bg-white border border-[#CCC] rounded-2xl overflow-hidden">
+                    <div class="px-5 py-4 border-b border-[#EEE] flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <h2 class="text-lg font-black text-[#1A1A1A]">전체 예약 리스트</h2>
+                            <p class="text-[12px] text-[#888] mt-1">승인 대기부터 완료 건까지 시간순으로 관리할 수 있습니다.</p>
+                        </div>
+                        <div class="inline-flex items-center gap-1 rounded-full bg-[#F9FAFC] border border-[#CCC] px-1.5 py-1 text-[11px] font-bold text-[#888]">
+                            <button type="button" class="rounded-full bg-white border border-[#CCC] px-3 py-1 text-[#1A1A1A]">리스트</button>
+                            <button type="button" class="rounded-full px-3 py-1 hover:text-[#1D3CFF] transition-colors">보드</button>
+                        </div>
+                    </div>
+
+                    <div class="divide-y divide-[#EEE]">
+                        <article class="px-5 py-5 hover:bg-[#FCFCFD] transition-colors">
+                            <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                                <div class="min-w-0">
+                                    <div class="flex flex-wrap items-center gap-2 mb-3">
+                                        <span class="status-pill pending">승인 대기</span>
+                                        <span class="text-[11px] font-bold text-[#FF6B2B]">오늘 안에 응답 필요</span>
+                                    </div>
+                                    <div class="flex items-start gap-3">
+                                        <div class="w-12 h-12 rounded-2xl bg-[#D3DEF2] text-[#1D3CFF] flex items-center justify-center text-lg font-black shrink-0">정</div>
+                                        <div class="min-w-0">
+                                            <h3 class="text-[18px] font-black text-[#1A1A1A] leading-tight">정우진 고객 · 증명사진</h3>
+                                            <p class="text-[13px] text-[#888] mt-1">4월 25일 (토) 09:00 · 강남 스튜디오 · 50,000C</p>
+                                            <p class="text-[13px] text-[#444] mt-3 leading-relaxed">
+                                                취업용 증명사진 촬영 요청. 자연스러운 보정 위주로 희망하며 오전 시간대 촬영을 선호한다고 남겼습니다.
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="flex flex-col sm:flex-row lg:flex-col gap-2 lg:min-w-[138px]">
+                                    <button type="button" class="rounded-xl border border-[#1D3CFF] bg-white px-4 py-2.5 text-sm font-bold text-[#1D3CFF] hover:bg-[#1D3CFF] hover:text-white transition-colors">수락</button>
+                                    <button type="button" class="rounded-xl border border-[#CCC] bg-white px-4 py-2.5 text-sm font-bold text-[#666] hover:border-[#888] hover:text-[#1A1A1A] transition-colors">거절</button>
+                                </div>
+                            </div>
+                        </article>
+
+                        <article class="px-5 py-5 hover:bg-[#FCFCFD] transition-colors">
+                            <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                                <div class="min-w-0">
+                                    <div class="flex flex-wrap items-center gap-2 mb-3">
+                                        <span class="status-pill confirmed">예약 확정</span>
+                                        <span class="text-[11px] font-bold text-[#1D3CFF]">D-1 리마인드 발송 예정</span>
+                                    </div>
+                                    <div class="flex items-start gap-3">
+                                        <div class="w-12 h-12 rounded-2xl bg-[#E6F7FF] text-[#0097FF] flex items-center justify-center text-lg font-black shrink-0">이</div>
+                                        <div class="min-w-0">
+                                            <h3 class="text-[18px] font-black text-[#1A1A1A] leading-tight">이수빈 고객 · 데이트 스냅</h3>
+                                            <p class="text-[13px] text-[#888] mt-1">4월 26일 (일) 13:00 - 15:00 · 홍대 / 연남동 · 150,000C</p>
+                                            <div class="mt-3 flex flex-wrap gap-2">
+                                                <span class="inline-flex items-center gap-1 rounded-full bg-[#F9FAFC] border border-[#CCC] px-3 py-1 text-[11px] font-semibold text-[#444]">
+                                                    <span class="mini-dot bg-[#1D3CFF]"></span> 커플 촬영
+                                                </span>
+                                                <span class="inline-flex items-center gap-1 rounded-full bg-[#F9FAFC] border border-[#CCC] px-3 py-1 text-[11px] font-semibold text-[#444]">
+                                                    <span class="mini-dot bg-[#22C55E]"></span> 보정본 10컷
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="flex flex-col sm:flex-row lg:flex-col gap-2 lg:min-w-[138px]">
+                                    <button type="button" class="rounded-xl border border-[#CCC] bg-white px-4 py-2.5 text-sm font-bold text-[#444] hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">상세 보기</button>
+                                    <button type="button" class="rounded-xl border border-[#CCC] bg-[#F9FAFC] px-4 py-2.5 text-sm font-bold text-[#888] hover:border-[#888] hover:text-[#444] transition-colors">일정 변경</button>
+                                </div>
+                            </div>
+                        </article>
+
+                        <article class="px-5 py-5 hover:bg-[#FCFCFD] transition-colors">
+                            <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                                <div class="min-w-0">
+                                    <div class="flex flex-wrap items-center gap-2 mb-3">
+                                        <span class="status-pill completed">촬영 완료</span>
+                                        <span class="text-[11px] font-bold text-[#1A8E40]">정산 대기 중</span>
+                                    </div>
+                                    <div class="flex items-start gap-3">
+                                        <div class="w-12 h-12 rounded-2xl bg-[#EEFBF3] text-[#1A8E40] flex items-center justify-center text-lg font-black shrink-0">김</div>
+                                        <div class="min-w-0">
+                                            <h3 class="text-[18px] font-black text-[#1A1A1A] leading-tight">김하늘 고객 · 졸업사진</h3>
+                                            <p class="text-[13px] text-[#888] mt-1">4월 21일 (화) 10:00 - 12:00 · 광화문 · 180,000C</p>
+                                            <p class="text-[13px] text-[#444] mt-3 leading-relaxed">
+                                                촬영은 정상 종료되었고, 1차 셀렉 가이드를 전달한 상태입니다. 보정본 전달 마감은 4월 28일로 예정되어 있습니다.
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="flex flex-col sm:flex-row lg:flex-col gap-2 lg:min-w-[138px]">
+                                    <button type="button" class="rounded-xl border border-[#CCC] bg-white px-4 py-2.5 text-sm font-bold text-[#444] hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">후기 요청</button>
+                                    <button type="button" class="rounded-xl border border-[#CCC] bg-[#F9FAFC] px-4 py-2.5 text-sm font-bold text-[#888] hover:border-[#888] hover:text-[#444] transition-colors">정산 보기</button>
+                                </div>
+                            </div>
+                        </article>
+
+                        <article class="px-5 py-5 hover:bg-[#FCFCFD] transition-colors">
+                            <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                                <div class="min-w-0">
+                                    <div class="flex flex-wrap items-center gap-2 mb-3">
+                                        <span class="status-pill rejected">작가 거절</span>
+                                        <span class="text-[11px] font-bold text-[#888]">응답 완료</span>
+                                    </div>
+                                    <div class="flex items-start gap-3">
+                                        <div class="w-12 h-12 rounded-2xl bg-[#F2F2F2] text-[#888] flex items-center justify-center text-lg font-black shrink-0">강</div>
+                                        <div class="min-w-0">
+                                            <h3 class="text-[18px] font-black text-[#1A1A1A] leading-tight">강지우 고객 · 웨딩 스냅</h3>
+                                            <p class="text-[13px] text-[#888] mt-1">4월 19일 (일) 14:00 · 한강공원 · 200,000C</p>
+                                            <p class="text-[13px] text-[#444] mt-3 leading-relaxed">
+                                                요청 시간대에 이미 기존 촬영이 있어 진행이 어려워 거절한 케이스입니다. 자동 환불 처리 영역이 들어올 자리를 고려해 안내 문구 영역을 확보했습니다.
+                                            </p>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="flex flex-col sm:flex-row lg:flex-col gap-2 lg:min-w-[138px]">
+                                    <button type="button" class="rounded-xl border border-[#CCC] bg-white px-4 py-2.5 text-sm font-bold text-[#444] hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">상세 보기</button>
+                                    <button type="button" class="rounded-xl border border-[#CCC] bg-[#F9FAFC] px-4 py-2.5 text-sm font-bold text-[#888] hover:border-[#888] hover:text-[#444] transition-colors">사유 수정</button>
+                                </div>
+                            </div>
+                        </article>
+                    </div>
+
+                    <div class="px-5 py-4 border-t border-[#EEE] flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <p class="text-[12px] text-[#888]">총 28건 중 1 - 4건 표시</p>
+                        <div class="flex items-center gap-1">
+                            <button type="button" class="w-9 h-9 rounded-lg border border-[#CCC] bg-white text-[#888] hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">‹</button>
+                            <button type="button" class="w-9 h-9 rounded-lg border border-[#1D3CFF] bg-[#EEF2FB] text-[#1D3CFF] font-bold">1</button>
+                            <button type="button" class="w-9 h-9 rounded-lg border border-[#CCC] bg-white text-[#444] font-bold hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">2</button>
+                            <button type="button" class="w-9 h-9 rounded-lg border border-[#CCC] bg-white text-[#444] font-bold hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">3</button>
+                            <button type="button" class="w-9 h-9 rounded-lg border border-[#CCC] bg-white text-[#888] hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">›</button>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="flex flex-col gap-6">
+                    <section class="bg-white border border-[#CCC] rounded-2xl p-5">
+                        <div class="flex items-center gap-2 mb-4">
+                            <div class="w-8 h-8 rounded-xl bg-[#EEF2FB] text-[#1D3CFF] flex items-center justify-center">
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                </svg>
+                            </div>
+                            <h2 class="text-base font-black text-[#1A1A1A]">운영 메모</h2>
+                        </div>
+
+                        <div class="space-y-4">
+                            <div class="rounded-2xl border border-[#CCC] bg-[#F9FAFC] p-4">
+                                <p class="text-[11px] font-bold text-[#888] mb-2">응답 SLA</p>
+                                <p class="text-[13px] text-[#444] leading-relaxed">승인 대기 예약은 1시간 이내 응답을 기본 목표로 두고, 24시간 이상 미응답 건은 별도 강조로 표시하는 구조를 고려했습니다.</p>
+                            </div>
+                            <div class="rounded-2xl border border-[#CCC] bg-[#F9FAFC] p-4">
+                                <p class="text-[11px] font-bold text-[#888] mb-2">후속 확장 포인트</p>
+                                <p class="text-[13px] text-[#444] leading-relaxed">추후 실제 데이터 연결 시 상태 필터, 날짜 범위, 고객 검색, 정렬, 보드/리스트 전환을 자연스럽게 이어 붙일 수 있도록 레이아웃을 잡았습니다.</p>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="bg-white border border-[#CCC] rounded-2xl p-5">
+                        <div class="flex items-center justify-between mb-4">
+                            <h2 class="text-base font-black text-[#1A1A1A]">오늘 처리 체크</h2>
+                            <span class="text-[11px] font-bold text-[#1D3CFF]">3 / 5 완료</span>
+                        </div>
+
+                        <div class="space-y-3">
+                            <div class="flex items-start gap-3">
+                                <div class="w-5 h-5 rounded-full bg-[#22C55E] text-white flex items-center justify-center text-[10px] font-black mt-0.5">✓</div>
+                                <div>
+                                    <p class="text-sm font-bold text-[#1A1A1A]">오전 촬영 일정 리마인드 전달</p>
+                                    <p class="text-[12px] text-[#888] mt-1">10:00 / 13:00 예약 고객에게 자동 메시지 발송 예정</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <div class="w-5 h-5 rounded-full bg-[#22C55E] text-white flex items-center justify-center text-[10px] font-black mt-0.5">✓</div>
+                                <div>
+                                    <p class="text-sm font-bold text-[#1A1A1A]">확정 예약 주소 재확인</p>
+                                    <p class="text-[12px] text-[#888] mt-1">홍대 / 연남동 야외 촬영 동선 메모 업데이트</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <div class="w-5 h-5 rounded-full bg-[#22C55E] text-white flex items-center justify-center text-[10px] font-black mt-0.5">✓</div>
+                                <div>
+                                    <p class="text-sm font-bold text-[#1A1A1A]">완료 건 보정본 전달 일정 체크</p>
+                                    <p class="text-[12px] text-[#888] mt-1">졸업사진 보정본 납기 4월 28일</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <div class="w-5 h-5 rounded-full border-2 border-[#CCC] mt-0.5"></div>
+                                <div>
+                                    <p class="text-sm font-bold text-[#1A1A1A]">승인 대기 2건 응답</p>
+                                    <p class="text-[12px] text-[#888] mt-1">정우진 / 강지우 고객 예약 요청 처리 필요</p>
+                                </div>
+                            </div>
+                            <div class="flex items-start gap-3">
+                                <div class="w-5 h-5 rounded-full border-2 border-[#CCC] mt-0.5"></div>
+                                <div>
+                                    <p class="text-sm font-bold text-[#1A1A1A]">거절 사유 템플릿 정리</p>
+                                    <p class="text-[12px] text-[#888] mt-1">일정 중복 / 촬영 범위 불일치 유형 분리</p>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+                </div>
+            </section>
+        </div>
+    </div>
+</main>
+
+</body>
+</html>

--- a/src/main/resources/templates/photographer/reservations.html
+++ b/src/main/resources/templates/photographer/reservations.html
@@ -203,23 +203,17 @@
                                 총 0건의 예약을 표시 중입니다.
                             </p>
                         </div>
-                        <div class="text-[12px] text-[#888]">
-                            상태 우선순위: 승인 대기 → 예약 확정 → 촬영 완료 → 거절 / 취소
-                        </div>
                     </div>
 
-                    <div th:if="${hasReservations}" class="divide-y divide-[#EEE]">
+                    <div th:if="${hasReservations}" id="reservation-list" class="divide-y divide-[#EEE]">
                         <article th:each="reservation : ${reservationItems}"
-                                 class="px-5 py-5 hover:bg-[#FCFCFD] transition-colors">
+                                 class="reservation-item px-5 py-5 hover:bg-[#FCFCFD] transition-colors">
                             <div class="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
                                 <div class="min-w-0">
                                     <div class="flex flex-wrap items-center gap-2 mb-3">
                                         <span class="status-pill"
                                               th:classappend="${reservation.statusClassName}"
                                               th:text="${reservation.statusLabel}">승인 대기</span>
-                                        <span class="text-[11px] font-bold"
-                                              th:classappend="${reservation.statusHintColorClass}"
-                                              th:text="${reservation.statusHint}">빠른 응답 필요</span>
                                     </div>
 
                                     <div class="flex items-start gap-3">
@@ -279,6 +273,10 @@
                         </article>
                     </div>
 
+                    <div th:if="${hasReservations}" id="pagination-bar"
+                         class="flex items-center justify-center gap-1 px-5 py-4 border-t border-[#EEE]">
+                    </div>
+
                     <div th:unless="${hasReservations}"
                          class="px-8 py-16 text-center">
                         <div class="text-5xl mb-4">📅</div>
@@ -289,62 +287,63 @@
                     </div>
                 </div>
 
-                <div class="flex flex-col gap-6">
-                    <section class="bg-white border border-[#CCC] rounded-2xl p-5">
-                        <div class="flex items-center gap-2 mb-4">
-                            <div class="w-8 h-8 rounded-xl bg-[#EEF2FB] text-[#1D3CFF] flex items-center justify-center">
-                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                                </svg>
-                            </div>
-                            <h2 class="text-base font-black text-[#1A1A1A]">운영 포인트</h2>
-                        </div>
-
-                        <div class="space-y-4">
-                            <div class="rounded-2xl border border-[#CCC] bg-[#F9FAFC] p-4">
-                                <p class="text-[11px] font-bold text-[#888] mb-2">승인 대기 대응</p>
-                                <p class="text-[13px] text-[#444] leading-relaxed">
-                                    승인 대기 예약은 리스트 최상단에 먼저 노출됩니다. 빠르게 응답할수록 고객 이탈 가능성을 낮출 수 있습니다.
-                                </p>
-                            </div>
-                            <div class="rounded-2xl border border-[#CCC] bg-[#F9FAFC] p-4">
-                                <p class="text-[11px] font-bold text-[#888] mb-2">검색 범위</p>
-                                <p class="text-[13px] text-[#444] leading-relaxed">
-                                    고객명, 서비스명, 촬영 장소를 기준으로 검색할 수 있도록 연결했습니다.
-                                </p>
-                            </div>
-                        </div>
-                    </section>
-
-                    <section class="bg-white border border-[#CCC] rounded-2xl p-5">
-                        <div class="flex items-center justify-between mb-4">
-                            <h2 class="text-base font-black text-[#1A1A1A]">빠른 요약</h2>
-                            <span class="text-[11px] font-bold text-[#1D3CFF]">실시간 기준</span>
-                        </div>
-
-                        <div class="space-y-3">
-                            <div class="flex items-center justify-between rounded-xl border border-[#EEE] bg-[#F9FAFC] px-4 py-3">
-                                <span class="text-sm text-[#444]">오늘 촬영</span>
-                                <span class="text-sm font-black text-[#1A1A1A]" th:text="${reservationManagementSummary.todayShootCount} + '건'">0건</span>
-                            </div>
-                            <div class="flex items-center justify-between rounded-xl border border-[#EEE] bg-[#F9FAFC] px-4 py-3">
-                                <span class="text-sm text-[#444]">승인 대기</span>
-                                <span class="text-sm font-black text-[#FF6B2B]" th:text="${reservationManagementSummary.pendingCount} + '건'">0건</span>
-                            </div>
-                            <div class="flex items-center justify-between rounded-xl border border-[#EEE] bg-[#F9FAFC] px-4 py-3">
-                                <span class="text-sm text-[#444]">이번 주 확정</span>
-                                <span class="text-sm font-black text-[#1D3CFF]" th:text="${reservationManagementSummary.confirmedCountThisWeek} + '건'">0건</span>
-                            </div>
-                            <div class="flex items-center justify-between rounded-xl border border-[#EEE] bg-[#F9FAFC] px-4 py-3">
-                                <span class="text-sm text-[#444]">완료 전환율</span>
-                                <span class="text-sm font-black text-[#1A8E40]" th:text="${reservationManagementSummary.completionRate} + '%'">0%</span>
-                            </div>
-                        </div>
-                    </section>
-                </div>
             </section>
         </div>
     </div>
+
+<script>
+(function () {
+    const PAGE_SIZE = 5;
+    const items = Array.from(document.querySelectorAll('.reservation-item'));
+    const bar = document.getElementById('pagination-bar');
+    if (!items.length || !bar) return;
+
+    let current = 0;
+    const totalPages = Math.ceil(items.length / PAGE_SIZE);
+
+    function render(page) {
+        current = page;
+        items.forEach((el, i) => {
+            el.style.display = (i >= page * PAGE_SIZE && i < (page + 1) * PAGE_SIZE) ? '' : 'none';
+        });
+        renderBar();
+    }
+
+    function btnClass(active) {
+        return active
+            ? 'w-8 h-8 flex items-center justify-center text-sm font-bold rounded-lg bg-[#1D3CFF] border border-[#1D3CFF] text-white'
+            : 'w-8 h-8 flex items-center justify-center text-sm font-semibold rounded-lg bg-white border border-[#CCC] text-[#888] hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors';
+    }
+
+    function renderBar() {
+        bar.innerHTML = '';
+
+        const prev = document.createElement('button');
+        prev.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M15 19l-7-7 7-7"/></svg>';
+        prev.className = btnClass(false) + (current === 0 ? ' opacity-30 cursor-not-allowed' : '');
+        prev.disabled = current === 0;
+        prev.onclick = () => render(current - 1);
+        bar.appendChild(prev);
+
+        for (let i = 0; i < totalPages; i++) {
+            const btn = document.createElement('button');
+            btn.textContent = i + 1;
+            btn.className = btnClass(i === current);
+            btn.onclick = () => render(i);
+            bar.appendChild(btn);
+        }
+
+        const next = document.createElement('button');
+        next.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M9 5l7 7-7 7"/></svg>';
+        next.className = btnClass(false) + (current === totalPages - 1 ? ' opacity-30 cursor-not-allowed' : '');
+        next.disabled = current === totalPages - 1;
+        next.onclick = () => render(current + 1);
+        bar.appendChild(next);
+    }
+
+    render(0);
+})();
+</script>
 </main>
 
 </body>

--- a/src/main/resources/templates/photographer/reviews.html
+++ b/src/main/resources/templates/photographer/reviews.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layouts/default :: layout(~{::title}, ~{::headExtra}, ~{::content})}">
+<head>
+    <title>후기 관리 - PICKASSO</title>
+    <th:block th:fragment="headExtra">
+        <style>
+            .star-filled { color: #FBBF24; }
+            .star-empty  { color: #E5E7EB; }
+            .review-card:hover { background: #FCFCFD; }
+        </style>
+    </th:block>
+</head>
+<body>
+
+<main th:fragment="content" class="max-w-[1216px] mx-auto px-6 py-8">
+    <div class="flex flex-col lg:flex-row gap-8 items-start">
+
+        <th:block th:replace="~{fragments/photographer-sidebar :: sidebar}" />
+
+        <div class="flex-1 min-w-0 flex flex-col gap-6">
+
+            <!-- 헤더 배너 -->
+            <section class="relative overflow-hidden rounded-2xl bg-gradient-to-br from-[#1D3CFF] to-[#0097FF] px-7 py-7 text-white">
+                <div class="relative z-10 flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
+                    <div class="min-w-0">
+                        <p class="text-[13px] font-semibold uppercase tracking-[0.22em] text-white/75 mb-2">Review Management</p>
+                        <h1 class="text-2xl leading-tight font-extrabold whitespace-nowrap">
+                            고객이 남긴 후기를 확인하세요
+                        </h1>
+                        <p class="text-[13px] text-white/75 mt-3 leading-relaxed">
+                            후기는 작가님의 신뢰도와 검색 노출에 영향을 줍니다.
+                        </p>
+                    </div>
+
+                    <div class="grid grid-cols-3 gap-3 xl:min-w-[360px]">
+                        <div class="rounded-2xl bg-white/10 border border-white/10 px-4 py-4 backdrop-blur-sm">
+                            <p class="text-[11px] text-white/70 mb-1">전체 후기</p>
+                            <p class="text-2xl font-black">5<span class="text-sm font-semibold ml-1">건</span></p>
+                        </div>
+                        <div class="rounded-2xl bg-white/10 border border-white/10 px-4 py-4 backdrop-blur-sm">
+                            <p class="text-[11px] text-white/70 mb-1">평균 별점</p>
+                            <p class="text-2xl font-black">4.8<span class="text-sm font-semibold ml-1">점</span></p>
+                        </div>
+                        <div class="rounded-2xl bg-white/10 border border-white/10 px-4 py-4 backdrop-blur-sm">
+                            <p class="text-[11px] text-white/70 mb-1">이번 달 신규</p>
+                            <p class="text-2xl font-black">2<span class="text-sm font-semibold ml-1">건</span></p>
+                        </div>
+                    </div>
+                </div>
+                <div class="absolute -right-12 -top-12 h-44 w-44 rounded-full bg-white/10"></div>
+                <div class="absolute right-28 bottom-[-52px] h-36 w-36 rounded-full bg-white/10"></div>
+            </section>
+
+            <!-- 별점 분포 + 안내 -->
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <!-- 별점 분포 -->
+                <div class="bg-white border border-[#CCC] rounded-2xl p-5">
+                    <h2 class="text-sm font-bold text-[#1A1A1A] mb-4">별점 분포</h2>
+                    <div class="flex flex-col gap-2">
+                        <div class="flex items-center gap-3">
+                            <span class="text-[12px] font-bold text-[#444] w-6 text-right">5★</span>
+                            <div class="flex-1 h-2 rounded-full bg-[#F0F0F0] overflow-hidden">
+                                <div class="h-full rounded-full bg-[#FBBF24]" style="width: 80%"></div>
+                            </div>
+                            <span class="text-[12px] text-[#888] w-6">4건</span>
+                        </div>
+                        <div class="flex items-center gap-3">
+                            <span class="text-[12px] font-bold text-[#444] w-6 text-right">4★</span>
+                            <div class="flex-1 h-2 rounded-full bg-[#F0F0F0] overflow-hidden">
+                                <div class="h-full rounded-full bg-[#FBBF24]" style="width: 20%"></div>
+                            </div>
+                            <span class="text-[12px] text-[#888] w-6">1건</span>
+                        </div>
+                        <div class="flex items-center gap-3">
+                            <span class="text-[12px] font-bold text-[#444] w-6 text-right">3★</span>
+                            <div class="flex-1 h-2 rounded-full bg-[#F0F0F0] overflow-hidden">
+                                <div class="h-full rounded-full bg-[#FBBF24]" style="width: 0%"></div>
+                            </div>
+                            <span class="text-[12px] text-[#888] w-6">0건</span>
+                        </div>
+                        <div class="flex items-center gap-3">
+                            <span class="text-[12px] font-bold text-[#444] w-6 text-right">2★</span>
+                            <div class="flex-1 h-2 rounded-full bg-[#F0F0F0] overflow-hidden">
+                                <div class="h-full rounded-full bg-[#FBBF24]" style="width: 0%"></div>
+                            </div>
+                            <span class="text-[12px] text-[#888] w-6">0건</span>
+                        </div>
+                        <div class="flex items-center gap-3">
+                            <span class="text-[12px] font-bold text-[#444] w-6 text-right">1★</span>
+                            <div class="flex-1 h-2 rounded-full bg-[#F0F0F0] overflow-hidden">
+                                <div class="h-full rounded-full bg-[#FBBF24]" style="width: 0%"></div>
+                            </div>
+                            <span class="text-[12px] text-[#888] w-6">0건</span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- 안내 -->
+                <div class="bg-[#F9FAFC] border border-[#CCC] rounded-2xl p-5 flex flex-col justify-center gap-3">
+                    <div class="flex items-start gap-3">
+                        <div class="w-8 h-8 rounded-xl bg-[#EEF2FB] text-[#1D3CFF] flex items-center justify-center shrink-0">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                            </svg>
+                        </div>
+                        <div>
+                            <p class="text-[13px] font-bold text-[#1A1A1A] mb-0.5">후기는 촬영 완료 후 고객이 작성합니다</p>
+                            <p class="text-[12px] text-[#888] leading-relaxed">예약 상태가 <span class="font-semibold text-[#1A8E40]">촬영 완료</span>로 전환된 예약에 한해 고객이 후기를 남길 수 있습니다.</p>
+                        </div>
+                    </div>
+                    <div class="flex items-start gap-3">
+                        <div class="w-8 h-8 rounded-xl bg-[#FFF4EE] text-[#FF6B2B] flex items-center justify-center shrink-0">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/>
+                            </svg>
+                        </div>
+                        <div>
+                            <p class="text-[13px] font-bold text-[#1A1A1A] mb-0.5">후기 삭제 및 수정은 불가합니다</p>
+                            <p class="text-[12px] text-[#888] leading-relaxed">후기는 고객만 수정·삭제할 수 있으며, 부적절한 후기는 고객센터를 통해 신고할 수 있습니다.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 후기 목록 -->
+            <div class="bg-white border border-[#CCC] rounded-2xl overflow-hidden">
+                <div class="px-5 py-4 border-b border-[#EEE] flex items-center justify-between">
+                    <div>
+                        <h2 class="text-lg font-black text-[#1A1A1A]">전체 후기</h2>
+                        <p class="text-[12px] text-[#888] mt-1">총 5건의 후기가 있습니다.</p>
+                    </div>
+                </div>
+
+                <div class="divide-y divide-[#EEE]">
+
+                    <!-- 후기 카드 1 -->
+                    <article class="review-card px-5 py-5 transition-colors">
+                        <div class="flex items-start justify-between gap-4 mb-3">
+                            <div class="flex items-center gap-3">
+                                <div class="w-10 h-10 rounded-full bg-[#D3DEF2] text-[#1D3CFF] flex items-center justify-center text-sm font-black shrink-0">최</div>
+                                <div>
+                                    <p class="text-sm font-bold text-[#1A1A1A]">최유진</p>
+                                    <p class="text-[11px] text-[#888]">졸업사진 촬영 · 2026.04.08</p>
+                                </div>
+                            </div>
+                            <div class="flex items-center gap-0.5 shrink-0">
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <span class="text-[12px] font-bold text-[#1A1A1A] ml-1">5.0</span>
+                            </div>
+                        </div>
+                        <p class="text-[13px] text-[#444] leading-relaxed">작가님이 너무 친절하시고 사진도 예쁘게 잘 나왔어요! 다음에도 꼭 다시 이용하고 싶습니다. 분위기도 너무 좋았어요.</p>
+                    </article>
+
+                    <!-- 후기 카드 2 -->
+                    <article class="review-card px-5 py-5 transition-colors">
+                        <div class="flex items-start justify-between gap-4 mb-3">
+                            <div class="flex items-center gap-3">
+                                <div class="w-10 h-10 rounded-full bg-[#D3DEF2] text-[#1D3CFF] flex items-center justify-center text-sm font-black shrink-0">박</div>
+                                <div>
+                                    <p class="text-sm font-bold text-[#1A1A1A]">박준서</p>
+                                    <p class="text-[11px] text-[#888]">데이트 스냅 (2인) · 2026.04.05</p>
+                                </div>
+                            </div>
+                            <div class="flex items-center gap-0.5 shrink-0">
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <span class="text-[12px] font-bold text-[#1A1A1A] ml-1">5.0</span>
+                            </div>
+                        </div>
+                        <p class="text-[13px] text-[#444] leading-relaxed">포즈 추천도 많이 해주시고 편안한 분위기에서 촬영할 수 있어서 좋았습니다. 보정본도 너무 맘에 들어요!</p>
+                    </article>
+
+                    <!-- 후기 카드 3 -->
+                    <article class="review-card px-5 py-5 transition-colors">
+                        <div class="flex items-start justify-between gap-4 mb-3">
+                            <div class="flex items-center gap-3">
+                                <div class="w-10 h-10 rounded-full bg-[#D3DEF2] text-[#1D3CFF] flex items-center justify-center text-sm font-black shrink-0">이</div>
+                                <div>
+                                    <p class="text-sm font-bold text-[#1A1A1A]">이수민</p>
+                                    <p class="text-[11px] text-[#888]">프로필 사진 촬영 · 2026.03.29</p>
+                                </div>
+                            </div>
+                            <div class="flex items-center gap-0.5 shrink-0">
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-empty" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <span class="text-[12px] font-bold text-[#1A1A1A] ml-1">4.0</span>
+                            </div>
+                        </div>
+                        <p class="text-[13px] text-[#444] leading-relaxed">전반적으로 만족스러운 촬영이었어요. 장소 안내가 조금 더 자세했으면 좋겠다는 생각이 들었지만, 사진 결과물은 정말 마음에 들어요.</p>
+                    </article>
+
+                    <!-- 후기 카드 4 -->
+                    <article class="review-card px-5 py-5 transition-colors">
+                        <div class="flex items-start justify-between gap-4 mb-3">
+                            <div class="flex items-center gap-3">
+                                <div class="w-10 h-10 rounded-full bg-[#D3DEF2] text-[#1D3CFF] flex items-center justify-center text-sm font-black shrink-0">정</div>
+                                <div>
+                                    <p class="text-sm font-bold text-[#1A1A1A]">정다은</p>
+                                    <p class="text-[11px] text-[#888]">졸업사진 촬영 · 2026.03.15</p>
+                                </div>
+                            </div>
+                            <div class="flex items-center gap-0.5 shrink-0">
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <span class="text-[12px] font-bold text-[#1A1A1A] ml-1">5.0</span>
+                            </div>
+                        </div>
+                        <p class="text-[13px] text-[#444] leading-relaxed">졸업 기념으로 찍었는데 정말 소중한 추억이 됐어요. 작가님이 긴장된 저를 편하게 해주셔서 자연스러운 사진이 많이 나왔어요. 강추합니다!</p>
+                    </article>
+
+                    <!-- 후기 카드 5 -->
+                    <article class="review-card px-5 py-5 transition-colors">
+                        <div class="flex items-start justify-between gap-4 mb-3">
+                            <div class="flex items-center gap-3">
+                                <div class="w-10 h-10 rounded-full bg-[#D3DEF2] text-[#1D3CFF] flex items-center justify-center text-sm font-black shrink-0">한</div>
+                                <div>
+                                    <p class="text-sm font-bold text-[#1A1A1A]">한지원</p>
+                                    <p class="text-[11px] text-[#888]">데이트 스냅 (2인) · 2026.03.02</p>
+                                </div>
+                            </div>
+                            <div class="flex items-center gap-0.5 shrink-0">
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <svg class="w-4 h-4 star-filled" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <span class="text-[12px] font-bold text-[#1A1A1A] ml-1">5.0</span>
+                            </div>
+                        </div>
+                        <p class="text-[13px] text-[#444] leading-relaxed">커플 스냅 처음 찍어봤는데 정말 자연스럽게 이끌어 주셨어요. 결과물도 너무 예쁘고 SNS에 올리니까 반응이 엄청 좋았어요!</p>
+                    </article>
+
+                </div>
+            </div>
+
+        </div>
+    </div>
+</main>
+
+</body>
+</html>

--- a/src/main/resources/templates/photographer/reviews.html
+++ b/src/main/resources/templates/photographer/reviews.html
@@ -8,6 +8,20 @@
             .star-filled { color: #FBBF24; }
             .star-empty  { color: #E5E7EB; }
             .review-card:hover { background: #FCFCFD; }
+            @keyframes floatA {
+                0%   { transform: translate(0px, 0px) scale(1); }
+                33%  { transform: translate(-65px, 35px) scale(1.08); }
+                66%  { transform: translate(-30px, -45px) scale(0.93); }
+                100% { transform: translate(0px, 0px) scale(1); }
+            }
+            @keyframes floatB {
+                0%   { transform: translate(0px, 0px) scale(1); }
+                33%  { transform: translate(30px, -55px) scale(0.92); }
+                66%  { transform: translate(-55px, -25px) scale(1.07); }
+                100% { transform: translate(0px, 0px) scale(1); }
+            }
+            .banner-circle-a { animation: floatA 22s ease-in-out infinite; }
+            .banner-circle-b { animation: floatB 32s ease-in-out infinite; }
         </style>
     </th:block>
 </head>
@@ -48,8 +62,8 @@
                         </div>
                     </div>
                 </div>
-                <div class="absolute -right-12 -top-12 h-44 w-44 rounded-full bg-white/10"></div>
-                <div class="absolute right-28 bottom-[-52px] h-36 w-36 rounded-full bg-white/10"></div>
+                <div class="banner-circle-a absolute -right-12 -top-12 h-44 w-44 rounded-full bg-white/10"></div>
+                <div class="banner-circle-b absolute right-28 bottom-[-52px] h-36 w-36 rounded-full bg-white/10"></div>
             </section>
 
             <!-- 별점 분포 + 안내 -->

--- a/src/main/resources/templates/photographer/service-detail.html
+++ b/src/main/resources/templates/photographer/service-detail.html
@@ -294,10 +294,10 @@
             </ul>
 
             <!-- CTA buttons -->
-            <button class="w-full bg-white border border-[#1D3CFF] text-[#1D3CFF] hover:bg-[#1D3CFF] hover:text-white active:bg-[#1530E0] font-semibold py-3 rounded-lg transition-colors text-sm"
-                    type="button">
+            <a th:href="@{/items/{id}/reserve(id=${item.id}, planId=${plan.id})}"
+               class="block w-full bg-white border border-[#1D3CFF] text-[#1D3CFF] hover:bg-[#1D3CFF] hover:text-white active:bg-[#1530E0] font-semibold py-3 rounded-lg transition-colors text-sm text-center">
               예약하기
-            </button>
+            </a>
           </div>
 
         </div>

--- a/src/main/resources/templates/photographer/settlement.html
+++ b/src/main/resources/templates/photographer/settlement.html
@@ -1,0 +1,334 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layouts/default :: layout(~{::title}, ~{::headExtra}, ~{::content})}">
+<head>
+    <title>수익 정산 - PICKASSO</title>
+    <th:block th:fragment="headExtra"></th:block>
+</head>
+<body>
+
+<main th:fragment="content" class="max-w-[1216px] mx-auto px-6 py-8">
+    <div class="flex flex-col lg:flex-row gap-8 items-start">
+
+        <th:block th:replace="~{fragments/photographer-sidebar :: sidebar}" />
+
+        <div class="flex-1 min-w-0 flex flex-col gap-6">
+
+            <!-- 페이지 타이틀 -->
+            <div>
+                <h1 class="text-2xl font-bold text-[#1A1A1A]">수익 정산</h1>
+                <p class="text-sm text-[#888] mt-1">서비스 제공 수익을 확인하고 계좌로 출금하세요.</p>
+            </div>
+
+            <!-- 통계 카드 -->
+            <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                <!-- 출금 가능 캐시 -->
+                <div class="bg-white border border-[#1D3CFF] rounded-2xl p-[22px] relative overflow-hidden">
+                    <div class="absolute top-0 left-0 right-0 h-[3px] bg-gradient-to-r from-[#1D3CFF] to-[#0097FF] rounded-t-2xl"></div>
+                    <div class="flex items-center gap-1.5 text-xs font-semibold text-[#888] tracking-wide mb-2.5">
+                        <svg class="w-3.5 h-3.5 text-[#AAA]" fill="currentColor" viewBox="0 0 16 16">
+                            <path d="M0 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v1H0V4zm0 3h16v5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V7zm3 2a.5.5 0 0 0 0 1h1a.5.5 0 0 0 0-1H3zm2.5 0a.5.5 0 0 0 0 1h5a.5.5 0 0 0 0-1h-5z"/>
+                        </svg>
+                        출금 가능 캐시
+                    </div>
+                    <div class="text-[28px] font-extrabold text-[#1D3CFF] leading-none tracking-tight mb-1.5">0<span class="text-base font-semibold text-[#888] ml-0.5">C</span></div>
+                    <div class="text-xs text-[#888]">즉시 출금 신청 가능</div>
+                    <div class="inline-flex items-center gap-1 text-[11px] font-semibold text-[#0097FF] bg-[#EEF6FF] rounded-md px-2 py-0.5 mt-1.5">
+                        <svg class="w-2.5 h-2.5" fill="currentColor" viewBox="0 0 16 16"><path d="m10.97 4.97-.02.022-3.473 4.425-2.093-2.094a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-1.071-1.05z"/><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/></svg>
+                        수수료 정산 완료
+                    </div>
+                </div>
+
+                <!-- 이번 달 총 수익 -->
+                <div class="bg-white border border-[#CCC] rounded-2xl p-[22px]">
+                    <div class="flex items-center gap-1.5 text-xs font-semibold text-[#888] tracking-wide mb-2.5">
+                        <svg class="w-3.5 h-3.5 text-[#AAA]" fill="currentColor" viewBox="0 0 16 16">
+                            <path d="M11 6.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1z"/><path d="M2 4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2H2zm13 2v6a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V6a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1z"/>
+                        </svg>
+                        이번 달 총 수익
+                    </div>
+                    <div class="text-[28px] font-extrabold text-[#1A1A1A] leading-none tracking-tight mb-1.5">0<span class="text-base font-semibold text-[#888] ml-0.5">C</span></div>
+                    <div class="text-xs text-[#888]" th:text="${#temporals.format(#temporals.createNow(), 'M월 1일')} + ' ~ ' + ${#temporals.format(#temporals.createNow(), 'M월 d일')}">이번 달</div>
+                </div>
+
+                <!-- 누적 총 정산액 -->
+                <div class="bg-white border border-[#CCC] rounded-2xl p-[22px]">
+                    <div class="flex items-center gap-1.5 text-xs font-semibold text-[#888] tracking-wide mb-2.5">
+                        <svg class="w-3.5 h-3.5 text-[#AAA]" fill="currentColor" viewBox="0 0 16 16">
+                            <path d="M4 10.781c.148 1.667 1.513 2.85 3.591 3.003V15h1.043v-1.216c2.27-.179 3.678-1.438 3.678-3.3 0-1.59-.947-2.51-2.956-3.028l-.722-.187V3.467c1.122.11 1.879.714 2.07 1.616h1.47c-.166-1.6-1.54-2.748-3.54-2.875V1H7.591v1.233c-1.939.23-3.27 1.472-3.27 3.156 0 1.454.966 2.483 2.661 2.917l.61.162v4.031c-1.149-.17-1.94-.8-2.07-1.718H4z"/>
+                        </svg>
+                        누적 총 정산액
+                    </div>
+                    <div class="text-[28px] font-extrabold text-[#1A1A1A] leading-none tracking-tight mb-1.5">0<span class="text-base font-semibold text-[#888] ml-0.5">C</span></div>
+                    <div class="text-xs text-[#888]">활동 시작 이후 누적</div>
+                    <div class="inline-flex items-center text-[11px] font-semibold text-[#888] bg-[#F9FAFC] border border-[#CCC] rounded-md px-2 py-0.5 mt-1.5">
+                        총 0건 정산 완료
+                    </div>
+                </div>
+            </div>
+
+            <!-- 정산 신청 카드 -->
+            <div class="bg-white border border-[#CCC] rounded-2xl p-7">
+                <h2 class="flex items-center gap-2 text-[17px] font-bold text-[#1A1A1A] mb-5">
+                    <svg class="w-5 h-5 text-[#1D3CFF]" fill="currentColor" viewBox="0 0 16 16">
+                        <path d="M4 10.781c.148 1.667 1.513 2.85 3.591 3.003V15h1.043v-1.216c2.27-.179 3.678-1.438 3.678-3.3 0-1.59-.947-2.51-2.956-3.028l-.722-.187V3.467c1.122.11 1.879.714 2.07 1.616h1.47c-.166-1.6-1.54-2.748-3.54-2.875V1H7.591v1.233c-1.939.23-3.27 1.472-3.27 3.156 0 1.454.966 2.483 2.661 2.917l.61.162v4.031c-1.149-.17-1.94-.8-2.07-1.718H4z"/>
+                    </svg>
+                    정산 신청
+                </h2>
+
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-5 mb-6">
+                    <div class="flex flex-col gap-1.5">
+                        <span class="text-xs font-semibold text-[#888]">출금 가능 캐시</span>
+                        <span class="text-xl font-extrabold text-[#1D3CFF]">0 C</span>
+                    </div>
+                    <div class="flex flex-col gap-1.5">
+                        <span class="text-xs font-semibold text-[#888]">최소 출금 금액</span>
+                        <span class="text-[15px] font-semibold text-[#1A1A1A]">10,000 C</span>
+                    </div>
+                    <div class="flex flex-col gap-1.5 sm:col-span-2">
+                        <span class="text-xs font-semibold text-[#888]">정산 받을 계좌</span>
+                        <div class="bg-[#F9FAFC] border border-[#CCC] rounded-[10px] px-4 py-3 text-sm text-[#444] flex items-center justify-between">
+                            <span>계좌 정보를 등록해주세요</span>
+                            <a href="#" class="text-xs text-[#0097FF] font-medium hover:underline">등록</a>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="flex gap-3 items-end mb-4">
+                    <div class="flex-1 relative">
+                        <label class="block text-xs font-semibold text-[#888] mb-1.5">출금 금액 입력</label>
+                        <input type="text" id="amountInput" value="" placeholder="0"
+                               class="w-full bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-[10px] px-4 pr-12 py-3 text-xl font-bold text-[#1A1A1A] font-sans focus:outline-none focus:border-[#0097FF] focus:shadow-[0_0_0_3px_rgba(0,151,255,0.08)] transition-all" />
+                        <span class="absolute right-4 bottom-3.5 text-sm font-semibold text-[#888] pointer-events-none">C</span>
+                    </div>
+                    <button onclick="setMaxAmount()" class="text-[13px] font-bold text-[#0097FF] bg-[#EEF6FF] border border-[#0097FF] rounded-lg px-4 h-12 whitespace-nowrap hover:bg-[#D8EDFF] transition-colors">전액</button>
+                </div>
+
+                <div class="text-xs text-[#888] leading-7 bg-[#F9FAFC] border border-[#CCC] rounded-lg px-4 py-3 mb-5">
+                    <strong class="text-[#1A1A1A]">수수료 안내</strong><br>
+                    출금 시 플랫폼 수수료 <strong class="text-[#1A1A1A]">5%</strong>가 차감됩니다. 영업일 기준 <strong class="text-[#1A1A1A]">1~3일</strong> 이내 등록 계좌로 이체됩니다.<br>
+                    출금 가능 캐시는 촬영 완료 후 <strong class="text-[#1A1A1A]">3일 경과분</strong>부터 적용됩니다.
+                </div>
+
+                <div class="flex items-center justify-between pt-5 border-t border-[#EEE]">
+                    <div class="flex flex-col gap-0.5">
+                        <span class="text-xs text-[#888] font-medium">실 수령액 (수수료 5% 차감)</span>
+                        <strong id="netAmountDisplay" class="text-[22px] font-extrabold text-[#1D3CFF] tracking-tight">0 C</strong>
+                    </div>
+                    <button onclick="openConfirmModal()"
+                            class="flex items-center gap-2 text-[15px] font-bold text-[#1D3CFF] bg-white border-[1.5px] border-[#1D3CFF] rounded-[10px] px-8 py-3.5 hover:bg-[#1D3CFF] hover:text-white transition-colors">
+                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 16 16">
+                            <path d="M0 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v1H0V4zm0 3h16v5a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V7zm3 2a.5.5 0 0 0 0 1h1a.5.5 0 0 0 0-1H3zm2.5 0a.5.5 0 0 0 0 1h5a.5.5 0 0 0 0-1h-5z"/>
+                        </svg>
+                        정산 신청하기
+                    </button>
+                </div>
+            </div>
+
+            <!-- 수익 내역 / 정산 내역 카드 -->
+            <div class="bg-white border border-[#CCC] rounded-2xl overflow-hidden">
+                <div class="flex items-center justify-between px-6 py-5 border-b border-[#EEE]">
+                    <h2 class="flex items-center gap-2 text-[17px] font-bold text-[#1A1A1A]">
+                        <svg class="w-5 h-5 text-[#1D3CFF]" fill="currentColor" viewBox="0 0 16 16">
+                            <path d="M0 1.5A1.5 1.5 0 0 1 1.5 0h13A1.5 1.5 0 0 1 16 1.5v13a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 0 14.5v-13zm1.5-.5a.5.5 0 0 0-.5.5V5h14V1.5a.5.5 0 0 0-.5-.5h-13zM16 6H0v8.5a.5.5 0 0 0 .5.5h15a.5.5 0 0 0 .5-.5V6z"/>
+                        </svg>
+                        수익 내역
+                    </h2>
+                    <div class="flex gap-1 bg-[#F9FAFC] border border-[#CCC] rounded-lg p-[3px]">
+                        <button id="tab-btn-earnings" onclick="switchTab('earnings')"
+                                class="tab-btn text-[13px] font-semibold text-[#1D3CFF] bg-white rounded-md px-3.5 py-1.5 shadow-[0_1px_4px_rgba(0,0,0,0.08)] transition-all">수익 내역</button>
+                        <button id="tab-btn-history" onclick="switchTab('history')"
+                                class="tab-btn text-[13px] font-semibold text-[#888] bg-transparent rounded-md px-3.5 py-1.5 transition-all">정산 내역</button>
+                    </div>
+                </div>
+
+                <!-- 필터 -->
+                <div class="flex items-center gap-2.5 px-6 py-3.5 bg-[#F9FAFC] border-b border-[#EEE]">
+                    <select class="text-[13px] text-[#444] bg-white border border-[#CCC] rounded-lg px-3 pr-7 py-1.5 appearance-none focus:outline-none focus:border-[#0097FF] cursor-pointer font-sans">
+                        <option th:text="${#temporals.format(#temporals.createNow(), 'yyyy년 M월')}">2026년 4월</option>
+                    </select>
+                    <select id="statusFilter" onchange="filterEarnings()" class="text-[13px] text-[#444] bg-white border border-[#CCC] rounded-lg px-3 pr-7 py-1.5 appearance-none focus:outline-none focus:border-[#0097FF] cursor-pointer font-sans">
+                        <option value="">전체 상태</option>
+                        <option value="available">출금 가능</option>
+                        <option value="hold">정산 대기</option>
+                        <option value="completed">출금 완료</option>
+                    </select>
+                </div>
+
+                <!-- 수익 내역 탭 -->
+                <div id="tab-earnings">
+                    <div class="text-center py-16 text-[#888]">
+                        <svg class="w-12 h-12 text-[#CCC] mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                        </svg>
+                        <p class="text-sm font-medium">아직 수익 내역이 없습니다.</p>
+                        <p class="text-xs text-[#AAA] mt-1">촬영 완료 후 수익이 반영됩니다.</p>
+                    </div>
+                </div>
+
+                <!-- 정산 내역 탭 -->
+                <div id="tab-history" class="hidden">
+                    <div class="text-center py-16 text-[#888]">
+                        <svg class="w-12 h-12 text-[#CCC] mx-auto mb-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+                        </svg>
+                        <p class="text-sm font-medium">아직 정산 내역이 없습니다.</p>
+                        <p class="text-xs text-[#AAA] mt-1">정산 신청 후 내역이 표시됩니다.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 안내 박스 -->
+            <div class="flex gap-2.5 bg-[#EEF2FB] border border-[#BFD0F5] rounded-[10px] px-4 py-3.5 text-[13px] text-[#444] leading-7">
+                <svg class="w-4 h-4 text-[#1D3CFF] shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 16 16">
+                    <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
+                    <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
+                </svg>
+                <div>
+                    <strong class="text-[#1A1A1A]">정산 안내사항</strong><br>
+                    · 출금 가능 캐시는 촬영 완료 후 고객 승인(또는 3일 자동 완료) 시 반영됩니다.<br>
+                    · 정산 신청은 영업일 기준 처리되며, 주말·공휴일 신청 건은 다음 영업일에 처리됩니다.<br>
+                    · 부정 거래 또는 분쟁이 발생한 예약의 수익은 해결 완료 전까지 보류될 수 있습니다.
+                </div>
+            </div>
+
+        </div>
+    </div>
+
+    <!-- 정산 확인 모달 -->
+    <div id="confirmModal" class="hidden fixed inset-0 bg-black/45 z-[200] flex items-center justify-center">
+        <div class="bg-white rounded-2xl w-[440px] max-w-[90vw] p-8 relative shadow-[0_20px_60px_rgba(0,0,0,0.15)]">
+            <button onclick="closeConfirmModal()" class="absolute top-5 right-5 text-[22px] text-[#888] hover:bg-[#F0F0F0] rounded-md px-1 leading-none transition-colors">✕</button>
+            <div class="text-xl font-bold text-[#1A1A1A] mb-1.5">정산 신청 확인</div>
+            <div class="text-[13px] text-[#888] mb-6">아래 내용을 확인 후 신청하세요.</div>
+
+            <div class="flex justify-between items-center py-2.5">
+                <span class="text-sm text-[#888]">신청 금액</span>
+                <span id="modal-amount" class="text-sm font-semibold text-[#1A1A1A]">0 C</span>
+            </div>
+            <div class="flex justify-between items-center py-2.5">
+                <span class="text-sm text-[#888]">플랫폼 수수료 (5%)</span>
+                <span id="modal-fee" class="text-sm font-semibold text-[#888]">−0 C</span>
+            </div>
+            <div class="flex justify-between items-center py-2.5">
+                <span class="text-sm text-[#888]">입금 계좌</span>
+                <span class="text-[13px] font-semibold text-[#1A1A1A]">—</span>
+            </div>
+            <div class="h-px bg-[#EEE] my-5"></div>
+            <div class="flex justify-between items-center py-3.5 border-t-2 border-[#1A1A1A] mt-1">
+                <span class="text-[15px] font-bold text-[#1A1A1A]">실 수령액</span>
+                <strong id="modal-net" class="text-[22px] font-extrabold text-[#1D3CFF] tracking-tight">0 C</strong>
+            </div>
+
+            <div class="flex gap-2.5 mt-6">
+                <button onclick="closeConfirmModal()" class="flex-1 text-sm font-semibold text-[#444] bg-white border border-[#CCC] rounded-[10px] py-3.5 hover:border-[#888] transition-colors">취소</button>
+                <button onclick="submitSettlement()" class="flex-[2] text-[15px] font-bold text-[#1D3CFF] bg-white border-[1.5px] border-[#1D3CFF] rounded-[10px] py-3.5 hover:bg-[#1D3CFF] hover:text-white transition-colors">신청 확정</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- 신청 완료 모달 -->
+    <div id="successModal" class="hidden fixed inset-0 bg-black/45 z-[300] flex items-center justify-center">
+        <div class="bg-white rounded-2xl w-[380px] max-w-[90vw] px-8 py-10 text-center shadow-[0_20px_60px_rgba(0,0,0,0.15)]">
+            <div class="w-16 h-16 bg-[#EEF2FB] rounded-full flex items-center justify-center mx-auto mb-5">
+                <svg class="w-8 h-8 text-[#1D3CFF]" fill="currentColor" viewBox="0 0 16 16">
+                    <path d="M13.854 3.646a.5.5 0 0 1 0 .708l-7 7a.5.5 0 0 1-.708 0l-3.5-3.5a.5.5 0 1 1 .708-.708L6.5 10.293l6.646-6.647a.5.5 0 0 1 .708 0z"/>
+                </svg>
+            </div>
+            <div class="text-xl font-bold text-[#1A1A1A] mb-2">정산 신청 완료!</div>
+            <div class="text-sm text-[#888] leading-7 mb-7">
+                정산 신청이 접수되었습니다.<br>
+                영업일 기준 1~3일 이내<br>
+                등록된 계좌로 입금됩니다.
+            </div>
+            <button onclick="closeSuccessModal()" class="w-full text-[15px] font-bold text-[#1D3CFF] bg-white border-[1.5px] border-[#1D3CFF] rounded-[10px] py-3.5 hover:bg-[#1D3CFF] hover:text-white transition-colors">확인</button>
+        </div>
+    </div>
+</main>
+
+<script th:inline="javascript">
+    const MAX_AMOUNT = 0;
+    const FEE_RATE = 0.05;
+
+    function formatNum(n) {
+        return n.toLocaleString('ko-KR');
+    }
+
+    function parseAmount(str) {
+        return parseInt(str.replace(/,/g, ''), 10) || 0;
+    }
+
+    const amountInput = document.getElementById('amountInput');
+    const netAmountDisplay = document.getElementById('netAmountDisplay');
+
+    function updateNetAmount() {
+        const raw = parseAmount(amountInput.value);
+        const net = Math.floor(raw * (1 - FEE_RATE));
+        netAmountDisplay.textContent = formatNum(net) + ' C';
+    }
+
+    amountInput.addEventListener('input', function () {
+        const raw = parseAmount(this.value);
+        const clamped = Math.min(raw, MAX_AMOUNT);
+        this.value = clamped > 0 ? formatNum(clamped) : '';
+        updateNetAmount();
+    });
+
+    function setMaxAmount() {
+        amountInput.value = MAX_AMOUNT > 0 ? formatNum(MAX_AMOUNT) : '';
+        updateNetAmount();
+    }
+
+    function switchTab(tabId) {
+        ['earnings', 'history'].forEach(id => {
+            const panel = document.getElementById('tab-' + id);
+            const btn = document.getElementById('tab-btn-' + id);
+            if (id === tabId) {
+                panel.classList.remove('hidden');
+                btn.classList.add('text-[#1D3CFF]', 'bg-white', 'shadow-[0_1px_4px_rgba(0,0,0,0.08)]');
+                btn.classList.remove('text-[#888]', 'bg-transparent');
+            } else {
+                panel.classList.add('hidden');
+                btn.classList.remove('text-[#1D3CFF]', 'bg-white', 'shadow-[0_1px_4px_rgba(0,0,0,0.08)]');
+                btn.classList.add('text-[#888]', 'bg-transparent');
+            }
+        });
+    }
+
+    function openConfirmModal() {
+        const raw = parseAmount(amountInput.value);
+        if (raw < 10000) {
+            alert('최소 출금 금액은 10,000 C 입니다.');
+            return;
+        }
+        const fee = Math.ceil(raw * FEE_RATE);
+        const net = raw - fee;
+        document.getElementById('modal-amount').textContent = formatNum(raw) + ' C';
+        document.getElementById('modal-fee').textContent = '−' + formatNum(fee) + ' C';
+        document.getElementById('modal-net').textContent = formatNum(net) + ' C';
+        document.getElementById('confirmModal').classList.remove('hidden');
+    }
+
+    function closeConfirmModal() {
+        document.getElementById('confirmModal').classList.add('hidden');
+    }
+
+    function submitSettlement() {
+        closeConfirmModal();
+        document.getElementById('successModal').classList.remove('hidden');
+    }
+
+    function closeSuccessModal() {
+        document.getElementById('successModal').classList.add('hidden');
+    }
+
+    document.getElementById('confirmModal').addEventListener('click', function (e) {
+        if (e.target === this) closeConfirmModal();
+    });
+    document.getElementById('successModal').addEventListener('click', function (e) {
+        if (e.target === this) closeSuccessModal();
+    });
+</script>
+
+</body>
+</html>

--- a/src/main/resources/templates/user/reservation-complete.html
+++ b/src/main/resources/templates/user/reservation-complete.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>예약 신청 완료 | PICKKASSO</title>
+  <link rel="stylesheet" th:href="@{/css/global.css}">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: { extend: { fontFamily: { sans: ['Pretendard', 'sans-serif'], angelica: ['WhiteAngelica', 'cursive'] } } }
+    }
+  </script>
+</head>
+<body class="bg-[#F9FAFC] text-[#1A1A1A] font-sans min-h-screen">
+
+<!-- ─── 헤더 ─────────────────────────────────────────── -->
+<header class="sticky top-0 z-50 bg-[#F9FAFC] border-b border-[#1A1A1A] h-16 flex items-center">
+  <div class="max-w-[1216px] w-full mx-auto px-6 flex items-center justify-between">
+    <a th:href="@{/}" class="flex items-center gap-2">
+      <img th:src="@{/images/logo.png}" alt="PICKKASSO 로고" class="h-8 w-auto">
+      <span class="font-angelica text-[16px] text-[#1D3CFF] tracking-wide">PICKASSO</span>
+    </a>
+    <nav class="flex items-center gap-1.5 text-sm" aria-label="예약 흐름">
+      <span class="text-[#888]">예약하기</span>
+      <span class="text-[#CCC]">›</span>
+      <span class="font-semibold text-[#1D3CFF]">예약 완료</span>
+    </nav>
+    <div class="w-[80px]"></div>
+  </div>
+</header>
+
+<!-- ─── 스텝 진행 표시 ─────────────────────────────────── -->
+<div class="bg-white border-b border-[#CCC]">
+  <div class="max-w-[1216px] mx-auto px-6 py-3 flex items-center gap-3 text-sm">
+    <div class="flex items-center gap-2">
+      <div class="w-6 h-6 rounded-full bg-[#0097FF] flex items-center justify-center flex-shrink-0">
+        <svg class="w-3.5 h-3.5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+        </svg>
+      </div>
+      <span class="font-medium text-[#444]">예약 정보 입력</span>
+    </div>
+    <div class="flex-1 h-px bg-[#1D3CFF] max-w-[60px]"></div>
+    <div class="flex items-center gap-2">
+      <div class="w-6 h-6 rounded-full bg-[#1D3CFF] flex items-center justify-center flex-shrink-0">
+        <svg class="w-3.5 h-3.5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
+          <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+        </svg>
+      </div>
+      <span class="font-bold text-[#1D3CFF]">예약 완료</span>
+    </div>
+  </div>
+</div>
+
+<!-- ─── 완료 콘텐츠 ───────────────────────────────────── -->
+<main class="max-w-[640px] mx-auto px-6 py-12">
+
+  <!-- 성공 아이콘 -->
+  <div class="flex flex-col items-center text-center mb-8">
+    <div class="w-20 h-20 rounded-full bg-[#EEF1FF] flex items-center justify-center mb-5">
+      <svg class="w-10 h-10 text-[#1D3CFF]" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+      </svg>
+    </div>
+    <h1 class="text-2xl font-bold text-[#1A1A1A] mb-2">예약 신청이 완료되었습니다!</h1>
+    <p class="text-sm text-[#888] leading-relaxed">
+      작가의 수락을 기다리고 있어요.<br>
+      작가가 수락하면 카카오톡 알림 또는 이메일로 알려드립니다.
+    </p>
+  </div>
+
+  <!-- 예약 정보 카드 -->
+  <div class="bg-white border border-[#CCC] rounded-2xl overflow-hidden mb-4">
+    <!-- 상단 배지 -->
+    <div class="bg-[#EEF1FF] border-b border-[#C4CCFF] px-6 py-3 flex items-center justify-between">
+      <span class="text-sm font-semibold text-[#1D3CFF]">예약 신청 완료</span>
+      <span class="text-xs text-[#888]"
+            th:text="'예약번호 #' + ${reservation.id}">예약번호 #0</span>
+    </div>
+
+    <div class="p-6 space-y-4">
+      <!-- 서비스 정보 -->
+      <div class="flex flex-col gap-1 pb-4 border-b border-[#CCC]">
+        <p class="text-xs font-medium text-[#0097FF]" th:text="${reservation.item.tag.name}">카테고리</p>
+        <p class="text-base font-bold text-[#1A1A1A]" th:text="${reservation.item.name}">서비스명</p>
+        <p class="text-sm text-[#888]"
+           th:text="${reservation.item.photographer.name != null ? reservation.item.photographer.name + ' 작가' : '작가'}">작가명</p>
+      </div>
+
+      <!-- 예약 상세 -->
+      <div class="grid grid-cols-2 gap-4 text-sm">
+        <div>
+          <p class="text-xs text-[#888] mb-1">촬영 일시</p>
+          <p class="font-semibold text-[#1A1A1A]"
+             th:text="${#temporals.format(reservation.scheduledAt, 'yyyy.MM.dd (EEE) HH:mm')}">날짜</p>
+        </div>
+        <div>
+          <p class="text-xs text-[#888] mb-1">촬영 시간</p>
+          <p class="font-semibold text-[#1A1A1A]"
+             th:text="${reservation.durationMinutes / 60} + '시간'">2시간</p>
+        </div>
+        <div class="col-span-2">
+          <p class="text-xs text-[#888] mb-1">촬영 장소</p>
+          <p class="font-semibold text-[#1A1A1A]" th:text="${reservation.address}">장소</p>
+        </div>
+        <div th:if="${reservation.memo != null and !#strings.isEmpty(reservation.memo)}" class="col-span-2">
+          <p class="text-xs text-[#888] mb-1">요청사항</p>
+          <p class="text-[#444] text-sm leading-relaxed" th:text="${reservation.memo}">요청사항</p>
+        </div>
+      </div>
+
+      <!-- 결제 금액 -->
+      <div class="border-t border-[#CCC] pt-4 flex items-center justify-between">
+        <span class="text-sm font-semibold text-[#1A1A1A]">결제 예정 금액</span>
+        <span class="text-lg font-bold text-[#1D3CFF]">
+          <span th:text="${#numbers.formatInteger(reservation.totalPrice, 1, 'COMMA')}">0</span> C
+        </span>
+      </div>
+    </div>
+  </div>
+
+  <!-- 안내 배너 -->
+  <div class="bg-[#FFFBEB] border border-[#FCD34D] rounded-xl px-5 py-4 mb-6 text-sm text-[#444] leading-relaxed">
+    <p class="font-semibold text-[#886600] mb-1">📌 알아두세요</p>
+    <ul class="space-y-1 text-xs text-[#886600]">
+      <li>• 작가가 수락하면 결제 캐시가 차감됩니다</li>
+      <li>• 작가 거절 시 전액 즉시 환불됩니다</li>
+      <li>• 예약 확정 후 작가의 연락처가 공개됩니다</li>
+    </ul>
+  </div>
+
+  <!-- 버튼 영역 -->
+  <div class="flex flex-col sm:flex-row gap-3">
+    <a th:href="@{/}"
+       class="flex-1 flex items-center justify-center gap-2 bg-white border border-[#CCC] text-[#444] font-semibold py-3.5 rounded-xl hover:border-[#888] hover:text-[#1A1A1A] transition-colors text-sm">
+      홈으로 돌아가기
+    </a>
+    <a th:href="@{/user/reservations}"
+       class="flex-1 flex items-center justify-center gap-2 bg-[#1D3CFF] hover:bg-[#1530E0] text-white font-bold py-3.5 rounded-xl transition-colors text-sm">
+      <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/>
+      </svg>
+      내 예약 내역 보기
+    </a>
+  </div>
+
+</main>
+
+</body>
+</html>

--- a/src/main/resources/templates/user/reservation.html
+++ b/src/main/resources/templates/user/reservation.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>예약하기 | PICKKASSO</title>
+  <title th:text="${item.name} + ' 예약 | PICKKASSO'">예약하기 | PICKKASSO</title>
   <link rel="stylesheet" th:href="@{/css/global.css}">
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -19,7 +19,6 @@
     }
   </script>
   <style>
-    /* ── 캘린더 ── */
     .cal-day {
       width: 2.25rem; height: 2.25rem;
       border-radius: 9999px;
@@ -29,13 +28,13 @@
       transition: background 0.12s;
     }
     .cal-day.other-month { color: #CCC; cursor: default; pointer-events: none; }
-    .cal-day.sun { color: #F87171; }
-    .cal-day.sat { color: #0097FF; }
+    .cal-day.disabled { color: #CCC; cursor: not-allowed; pointer-events: none; text-decoration: line-through; }
+    .cal-day.sun { color: #F87171; cursor: pointer; }
+    .cal-day.sat { color: #0097FF; cursor: pointer; }
     .cal-day.normal { color: #1A1A1A; cursor: pointer; }
-    .cal-day.normal:hover { background: #F0F3FF; }
+    .cal-day.sun:hover, .cal-day.sat:hover, .cal-day.normal:hover { background: #F0F3FF; }
     .cal-day.selected { background: #1D3CFF !important; color: #fff !important; cursor: default; }
 
-    /* ── 시간 슬롯 ── */
     .time-btn {
       padding: 0.625rem 0;
       border-radius: 0.5rem;
@@ -58,30 +57,25 @@
     .time-btn:disabled {
       border-color: #CCC; background: #F9FAFC; color: #CCC; cursor: not-allowed;
     }
-
   </style>
 </head>
 <body class="bg-[#F9FAFC] text-[#1A1A1A] font-sans">
 
-<!-- ══════════════════════════════════════════
-     예약 전용 헤더
-══════════════════════════════════════════ -->
+<!-- ─── 헤더 ─────────────────────────────────────────── -->
 <header class="sticky top-0 z-50 bg-[#F9FAFC] border-b border-[#1A1A1A] h-16 flex items-center">
   <div class="max-w-[1216px] w-full mx-auto px-6 flex items-center justify-between">
-    <!-- 로고 -->
     <a th:href="@{/}" class="flex items-center gap-2">
       <img th:src="@{/images/logo.png}" alt="PICKKASSO 로고" class="h-8 w-auto">
       <span class="font-angelica text-[16px] text-[#1D3CFF] tracking-wide">PICKASSO</span>
     </a>
 
-    <!-- 브레드크럼 -->
     <nav class="flex items-center gap-1.5 text-sm" aria-label="예약 흐름">
-      <a th:href="@{/}" class="text-[#888] hover:text-[#1D3CFF] transition-colors">서비스 상세</a>
+      <a th:href="@{/item/{id}(id=${item.id})}" class="text-[#888] hover:text-[#1D3CFF] transition-colors"
+         th:text="${item.name}">서비스 상세</a>
       <span class="text-[#CCC]">›</span>
       <span class="font-semibold text-[#1D3CFF]">예약하기</span>
     </nav>
 
-    <!-- 문의하기 -->
     <button type="button"
             class="text-sm font-medium border border-[#CCC] text-[#444] px-4 py-2 rounded-lg hover:border-[#888] hover:text-[#1A1A1A] transition-colors">
       문의하기
@@ -89,395 +83,384 @@
   </div>
 </header>
 
-<!-- ══════════════════════════════════════════
-     스텝 진행 표시
-══════════════════════════════════════════ -->
+<!-- ─── 스텝 진행 표시 ─────────────────────────────────── -->
 <div class="bg-white border-b border-[#CCC]">
-  <div class="max-w-[1216px] mx-auto px-6 py-4 flex justify-center">
-    <div class="flex items-center gap-0">
-
-      <!-- Step 1: 날짜·시간 (완료) -->
-      <div class="flex flex-col items-center">
-        <div class="w-8 h-8 rounded-full bg-[#1D3CFF] flex items-center justify-center">
-          <svg class="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
-          </svg>
-        </div>
-        <span class="text-xs mt-1 font-medium text-[#1D3CFF]">날짜 · 시간</span>
+  <div class="max-w-[1216px] mx-auto px-6 py-3 flex items-center gap-3 text-sm">
+    <div class="flex items-center gap-2">
+      <div class="w-6 h-6 rounded-full bg-[#1D3CFF] flex items-center justify-center flex-shrink-0">
+        <span class="text-white text-xs font-bold">1</span>
       </div>
-
-      <div class="w-14 h-0.5 bg-[#1D3CFF] mb-5 mx-1"></div>
-
-      <!-- Step 2: 촬영 장소 (완료) -->
-      <div class="flex flex-col items-center">
-        <div class="w-8 h-8 rounded-full bg-[#1D3CFF] flex items-center justify-center">
-          <svg class="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
-          </svg>
-        </div>
-        <span class="text-xs mt-1 font-medium text-[#1D3CFF]">촬영 장소</span>
+      <span class="font-semibold text-[#1D3CFF]">예약 정보 입력</span>
+    </div>
+    <div class="flex-1 h-px bg-[#CCC] max-w-[60px]"></div>
+    <div class="flex items-center gap-2">
+      <div class="w-6 h-6 rounded-full border border-[#CCC] bg-white flex items-center justify-center flex-shrink-0">
+        <span class="text-xs font-medium text-[#AAA]">2</span>
       </div>
-
-      <div class="w-14 h-0.5 bg-[#1D3CFF] mb-5 mx-1"></div>
-
-      <!-- Step 3: 옵션·결제 (현재) -->
-      <div class="flex flex-col items-center">
-        <div class="w-8 h-8 rounded-full border-2 border-[#1D3CFF] bg-white flex items-center justify-center">
-          <span class="text-xs font-bold text-[#1D3CFF]">3</span>
-        </div>
-        <span class="text-xs mt-1 font-bold text-[#1D3CFF]">옵션 · 결제</span>
-      </div>
-
-      <div class="w-14 h-0.5 bg-[#CCC] mb-5 mx-1"></div>
-
-      <!-- Step 4: 예약 완료 (비활성) -->
-      <div class="flex flex-col items-center">
-        <div class="w-8 h-8 rounded-full border-2 border-[#CCC] bg-white flex items-center justify-center">
-          <span class="text-xs font-medium text-[#AAA]">4</span>
-        </div>
-        <span class="text-xs mt-1 text-[#AAA]">예약 완료</span>
-      </div>
-
+      <span class="text-[#AAA]">예약 완료</span>
     </div>
   </div>
 </div>
 
-<!-- ══════════════════════════════════════════
-     메인 콘텐츠 (2컬럼)
-══════════════════════════════════════════ -->
+<!-- ─── 에러 메시지 ─────────────────────────────────── -->
+<div th:if="${errorMsg}" class="max-w-[1216px] mx-auto px-6 pt-4">
+  <div class="flex items-center gap-2 bg-red-50 border border-red-200 rounded-lg px-4 py-3 text-sm text-red-700">
+    <span>⚠️</span>
+    <span th:text="${errorMsg}">오류가 발생했습니다.</span>
+  </div>
+</div>
+
+<!-- ─── 메인 콘텐츠 ─────────────────────────────────────── -->
 <main class="max-w-[1216px] mx-auto px-6 py-8">
-  <div class="flex gap-8 items-start">
+  <form th:action="@{/items/{id}/reserve(id=${item.id})}" method="post">
+    <!-- 히든 필드 -->
+    <input type="hidden" name="planId" th:value="${selectedPlan?.id}">
+    <input type="hidden" name="scheduledDate" id="scheduledDate" value="">
+    <input type="hidden" name="scheduledHour" id="scheduledHour" value="">
 
-    <!-- ────────────────────────
-         좌측: 폼 섹션
-    ──────────────────────── -->
-    <div class="flex-1 min-w-0 flex flex-col gap-6">
+    <div class="flex gap-8 items-start">
 
-      <!-- ① 촬영 날짜 선택 ──────────── -->
-      <section class="bg-white border border-[#CCC] rounded-2xl p-6">
-        <h2 class="text-base font-semibold text-[#1A1A1A] mb-5 flex items-center gap-2">
-          <span>📅</span><span>촬영 날짜 선택</span>
-        </h2>
+      <!-- ── 좌측 폼 섹션 ──────────────────────── -->
+      <div class="flex-1 min-w-0 flex flex-col gap-6">
 
-        <!-- 캘린더 헤더 -->
-        <div class="flex items-center justify-between mb-3">
-          <button id="prevMonth" type="button"
-                  class="w-8 h-8 flex items-center justify-center rounded-full text-lg text-[#444] hover:bg-[#F9FAFC] transition-colors">
-            ‹
-          </button>
-          <span id="calendarTitle" class="text-sm font-semibold text-[#1A1A1A]">2026년 4월</span>
-          <button id="nextMonth" type="button"
-                  class="w-8 h-8 flex items-center justify-center rounded-full text-lg text-[#444] hover:bg-[#F9FAFC] transition-colors">
-            ›
-          </button>
-        </div>
+        <!-- ① 촬영 날짜 선택 -->
+        <section class="bg-white border border-[#CCC] rounded-2xl p-6">
+          <h2 class="text-base font-semibold text-[#1A1A1A] mb-5 flex items-center gap-2">
+            <span>📅</span><span>촬영 날짜 선택</span>
+          </h2>
+          <p class="text-xs text-[#888] mb-4"
+             th:text="'촬영 ' + ${item.minBookingLeadTime} + '일 전까지 예약 가능 · 오늘 기준 최소 예약 가능일 이전 날짜는 선택 불가'">
+            최소 예약 가능일 이전 날짜는 선택 불가합니다.
+          </p>
 
-        <!-- 요일 헤더 -->
-        <div class="grid grid-cols-7 mb-1">
-          <div class="text-center text-xs font-semibold text-red-400 py-2">일</div>
-          <div class="text-center text-xs font-semibold text-[#888] py-2">월</div>
-          <div class="text-center text-xs font-semibold text-[#888] py-2">화</div>
-          <div class="text-center text-xs font-semibold text-[#888] py-2">수</div>
-          <div class="text-center text-xs font-semibold text-[#888] py-2">목</div>
-          <div class="text-center text-xs font-semibold text-[#888] py-2">금</div>
-          <div class="text-center text-xs font-semibold text-[#0097FF] py-2">토</div>
-        </div>
-
-        <!-- 날짜 그리드 -->
-        <div id="calendarGrid" class="grid grid-cols-7 gap-y-1"></div>
-      </section>
-
-      <!-- ② 촬영 시작 시간 ──────────── -->
-      <section class="bg-white border border-[#CCC] rounded-2xl p-6">
-        <h2 class="text-base font-semibold text-[#1A1A1A] mb-1 flex items-center gap-2">
-          <span>🕐</span><span>촬영 시작 시간</span>
-        </h2>
-        <p class="text-xs text-[#888] mb-4">작가의 예약 가능 시간: 10:00 - 22:00 &nbsp;·&nbsp; 회색으로 표시된 시간은 예약 불가</p>
-
-        <div id="timeSlots" class="grid grid-cols-4 gap-2"></div>
-      </section>
-
-      <!-- ③ 촬영 장소 ──────────── -->
-      <section class="bg-white border border-[#CCC] rounded-2xl p-6">
-        <h2 class="text-base font-semibold text-[#1A1A1A] mb-4 flex items-center gap-2">
-          <span>📍</span><span>촬영 장소</span>
-        </h2>
-
-        <label class="text-sm font-medium text-[#444] mb-2 block">장소 검색</label>
-        <div class="relative mb-3">
-          <input type="text" value="서울특별시 마포구 홍대입구역"
-                 class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg pl-9 pr-4 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] focus:outline-none focus:border-[#0097FF] focus:ring-1 focus:ring-[#0097FF]">
-          <svg class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[#888]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/>
-          </svg>
-        </div>
-
-        <!-- 지도 플레이스홀더 -->
-        <div class="w-full h-40 bg-[#D3DEF2] rounded-xl flex flex-col items-center justify-center gap-2 mb-3">
-          <svg class="w-8 h-8 text-[#888]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
-                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"/>
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"/>
-          </svg>
-          <span class="text-sm text-[#888]">서울 마포구 홍대입구역 일대</span>
-        </div>
-
-        <!-- 거리 추가요금 경고 -->
-        <div class="flex items-center gap-2 bg-[#FFFBEB] border border-[#FCD34D] rounded-lg px-4 py-2.5 mb-4">
-          <span class="text-base">⚠️</span>
-          <span class="text-sm text-[#444]">
-            기준지점(청정동)에서 1.2km &nbsp;·&nbsp; 거리 추가요금
-            <span class="font-semibold text-[#1D3CFF]">+1,200원</span> 예상
-          </span>
-        </div>
-
-        <label class="text-sm font-medium text-[#444] mb-2 block">상세 장소 안내</label>
-        <input type="text" value="홍대입구역 9번 출구 앞"
-               class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-4 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] focus:outline-none focus:border-[#0097FF] focus:ring-1 focus:ring-[#0097FF] mb-1">
-        <p class="text-xs text-[#888]">작가가 찾을 수 있도록 구체적으로 알려주세요</p>
-      </section>
-
-      <!-- ④ 예약자 정보 ──────────── -->
-      <section class="bg-white border border-[#CCC] rounded-2xl p-6">
-        <h2 class="text-base font-semibold text-[#1A1A1A] mb-4 flex items-center gap-2">
-          <span>👤</span><span>예약자 정보</span>
-        </h2>
-
-        <!-- 안내 박스 -->
-        <div class="flex items-start gap-2 bg-[#EBF5FF] border border-[#BFDBFE] rounded-lg px-4 py-3 mb-5">
-          <svg class="w-4 h-4 text-[#0097FF] flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
-            <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
-          </svg>
-          <span class="text-sm text-[#444]">예약 확정 후 작가에게 연락처가 공개됩니다. 정확하게 입력해 주세요.</span>
-        </div>
-
-        <div class="grid grid-cols-2 gap-4 mb-4">
-          <div>
-            <label class="text-sm font-medium text-[#444] mb-1.5 block">이름 <span class="text-red-400">*</span></label>
-            <input type="text" th:value="${member?.name}"
-                   class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-4 py-2.5 text-sm text-[#1A1A1A] focus:outline-none focus:border-[#0097FF] focus:ring-1 focus:ring-[#0097FF]">
+          <!-- 캘린더 헤더 -->
+          <div class="flex items-center justify-between mb-3">
+            <button id="prevMonth" type="button"
+                    class="w-8 h-8 flex items-center justify-center rounded-full text-lg text-[#444] hover:bg-[#F9FAFC] transition-colors">
+              ‹
+            </button>
+            <span id="calendarTitle" class="text-sm font-semibold text-[#1A1A1A]"></span>
+            <button id="nextMonth" type="button"
+                    class="w-8 h-8 flex items-center justify-center rounded-full text-lg text-[#444] hover:bg-[#F9FAFC] transition-colors">
+              ›
+            </button>
           </div>
-          <div>
-            <label class="text-sm font-medium text-[#444] mb-1.5 block">연락처 <span class="text-red-400">*</span></label>
-            <input type="tel" th:value="${member?.phone}"
-                   class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-4 py-2.5 text-sm text-[#1A1A1A] focus:outline-none focus:border-[#0097FF] focus:ring-1 focus:ring-[#0097FF]">
+
+          <!-- 요일 헤더 -->
+          <div class="grid grid-cols-7 mb-1">
+            <div class="text-center text-xs font-semibold text-red-400 py-2">일</div>
+            <div class="text-center text-xs font-semibold text-[#888] py-2">월</div>
+            <div class="text-center text-xs font-semibold text-[#888] py-2">화</div>
+            <div class="text-center text-xs font-semibold text-[#888] py-2">수</div>
+            <div class="text-center text-xs font-semibold text-[#888] py-2">목</div>
+            <div class="text-center text-xs font-semibold text-[#888] py-2">금</div>
+            <div class="text-center text-xs font-semibold text-[#0097FF] py-2">토</div>
           </div>
-        </div>
 
-        <div class="mb-4">
-          <label class="text-sm font-medium text-[#444] mb-1.5 block">촬영 인원 <span class="text-red-400">*</span></label>
-          <select class="w-32 bg-[#F9FAFC] border border-[#CCC] rounded-lg px-4 py-2.5 text-sm text-[#1A1A1A] focus:outline-none focus:border-[#0097FF] focus:ring-1 focus:ring-[#0097FF] cursor-pointer">
-            <option value="1">1명</option>
-            <option value="2" selected>2명</option>
-            <option value="3">3명</option>
-            <option value="4">4명</option>
-            <option value="5">5명 이상</option>
-          </select>
-        </div>
+          <!-- 날짜 그리드 -->
+          <div id="calendarGrid" class="grid grid-cols-7 gap-y-1"></div>
+        </section>
 
-        <div>
-          <label class="text-sm font-medium text-[#444] mb-1.5 block">작가에게 전달할 요청사항</label>
-          <textarea rows="4"
-                    placeholder="원하는 분위기, 특별한 요청사항, 촬영 컨셉 등을 자유롭게 적어주세요."
-                    class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-4 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] focus:outline-none focus:border-[#0097FF] focus:ring-1 focus:ring-[#0097FF] resize-none"></textarea>
-        </div>
-      </section>
+        <!-- ② 촬영 시작 시간 -->
+        <section class="bg-white border border-[#CCC] rounded-2xl p-6">
+          <h2 class="text-base font-semibold text-[#1A1A1A] mb-1 flex items-center gap-2">
+            <span>🕐</span><span>촬영 시작 시간</span>
+          </h2>
+          <p class="text-xs text-[#888] mb-4">예약 가능 시간: 09:00 ~ 20:00 &nbsp;·&nbsp; 회색으로 표시된 시간은 예약 불가</p>
+          <div id="timeSlots" class="grid grid-cols-4 gap-2"></div>
+        </section>
 
-      <!-- ⑤ 캐시 결제 ──────────── -->
-      <section class="bg-white border border-[#CCC] rounded-2xl p-6">
-        <h2 class="text-base font-semibold text-[#1A1A1A] mb-4 flex items-center gap-2">
-          <span>💳</span><span>캐시 결제</span>
-        </h2>
+        <!-- ③ 촬영 장소 -->
+        <section class="bg-white border border-[#CCC] rounded-2xl p-6">
+          <h2 class="text-base font-semibold text-[#1A1A1A] mb-4 flex items-center gap-2">
+            <span>📍</span><span>촬영 장소</span>
+          </h2>
 
-        <!-- 보유 캐시 -->
-        <div class="flex items-center justify-between bg-[#F9FAFC] border border-[#CCC] rounded-xl px-5 py-4 mb-4">
-          <div>
-            <p class="text-xs text-[#888] mb-0.5">보유 캐시</p>
-            <p class="text-xl font-bold text-[#1A1A1A]">
-              <span th:text="${member != null and member.cache != null ? #numbers.formatInteger(member.cache, 0, 'COMMA') : '0'}">0</span>
-              <span class="text-[#1D3CFF]">C</span>
-            </p>
+          <div th:if="${item.itemType.name() == 'IN'}"
+               class="flex items-center gap-2 bg-[#EBF5FF] border border-[#BFDBFE] rounded-lg px-4 py-3 mb-4">
+            <span class="text-sm">🏢</span>
+            <span class="text-sm text-[#444]">스튜디오 촬영 – 작가 스튜디오로 방문해 주세요.</span>
           </div>
-          <button type="button"
-                  class="text-sm font-semibold border border-[#1D3CFF] text-[#1D3CFF] px-4 py-2 rounded-lg hover:bg-[#1D3CFF] hover:text-white active:bg-[#1530E0] transition-colors">
-            + 캐시 충전
-          </button>
-        </div>
 
-        <!-- 차감 동의 -->
-        <label class="flex items-start gap-3 cursor-pointer mb-4 select-none">
-          <div class="w-5 h-5 rounded border-2 border-[#1D3CFF] bg-[#1D3CFF] flex items-center justify-center flex-shrink-0 mt-0.5">
-            <svg class="w-3 h-3 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+          <div class="mb-4">
+            <label class="text-sm font-medium text-[#444] mb-1.5 block">
+              장소 주소
+              <span th:if="${item.itemType.name() == 'OUT'}" class="text-red-400">*</span>
+            </label>
+            <input type="text" name="address" id="addressInput"
+                   th:value="${item.itemType.name() == 'IN' ? item.address : ''}"
+                   th:readonly="${item.itemType.name() == 'IN'}"
+                   placeholder="촬영하고 싶은 장소의 주소를 입력해 주세요"
+                   class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-4 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] focus:outline-none focus:border-[#0097FF] focus:ring-1 focus:ring-[#0097FF]">
+          </div>
+
+          <div>
+            <label class="text-sm font-medium text-[#444] mb-1.5 block">상세 장소 안내</label>
+            <input type="text" name="detailAddress"
+                   placeholder="예: 9번 출구 앞, 공원 입구 등 찾기 쉬운 장소를 알려주세요"
+                   class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-4 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] focus:outline-none focus:border-[#0097FF] focus:ring-1 focus:ring-[#0097FF] mb-1">
+            <p class="text-xs text-[#888]">작가가 찾아올 수 있도록 구체적으로 알려주세요</p>
+          </div>
+        </section>
+
+        <!-- ④ 예약자 정보 -->
+        <section class="bg-white border border-[#CCC] rounded-2xl p-6">
+          <h2 class="text-base font-semibold text-[#1A1A1A] mb-4 flex items-center gap-2">
+            <span>👤</span><span>예약자 정보</span>
+          </h2>
+
+          <div class="flex items-start gap-2 bg-[#EBF5FF] border border-[#BFDBFE] rounded-lg px-4 py-3 mb-5">
+            <svg class="w-4 h-4 text-[#0097FF] flex-shrink-0 mt-0.5" fill="currentColor" viewBox="0 0 20 20">
+              <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/>
             </svg>
-          </div>
-          <span class="text-sm text-[#444]">
-            예약 확정 시 <span id="cashCheckLabel" class="font-bold text-[#1D3CFF]">151,200</span> 캐시가 차감됩니다
-          </span>
-        </label>
-
-        <!-- 안내 -->
-        <div class="border-t border-[#CCC] pt-4 space-y-1.5">
-          <p class="text-xs text-[#888]">• 예약 거절 또는 작가가 수락하면 취소 시 정책에 따라 환불 처리됩니다</p>
-          <p class="text-xs text-[#888]">• 촬영 7일 전 이전 취소: 전액 환불</p>
-          <p class="text-xs text-[#888]">• 캐시는 PICKKASSO 플랫폼 내에서만 사용 가능</p>
-        </div>
-      </section>
-
-    </div> <!-- end 좌측 -->
-
-    <!-- ────────────────────────
-         우측: 요약 패널 (sticky)
-    ──────────────────────── -->
-    <div class="w-[340px] flex-shrink-0">
-      <div class="sticky top-[84px] flex flex-col gap-4">
-
-        <!-- 서비스 정보 카드 -->
-        <div class="bg-white border border-[#CCC] rounded-2xl overflow-hidden">
-          <!-- 대표 이미지 -->
-          <div class="relative">
-            <div class="w-full h-44 bg-[#D3DEF2] flex items-center justify-center">
-              <span class="text-sm text-[#888]">서비스 대표 이미지</span>
-            </div>
-            <span class="absolute top-3 left-3 bg-[#1D3CFF] text-white text-xs font-semibold px-3 py-1 rounded-full">
-              방문 촬영
-            </span>
+            <span class="text-sm text-[#444]">예약 확정 후 작가에게 연락처가 공개됩니다. 정확하게 입력해 주세요.</span>
           </div>
 
-          <div class="p-5">
-            <!-- 카테고리 + 제목 -->
-            <p class="text-xs font-medium text-[#0097FF] mb-1">데이트 스냅</p>
-            <h3 class="text-sm font-bold text-[#1A1A1A] mb-3">감성 데이트 스냅 2시간 패키지</h3>
-
-            <!-- 작가 정보 -->
-            <div class="flex items-center gap-2 pb-4 mb-4 border-b border-[#CCC]">
-              <div class="w-7 h-7 rounded-full bg-[#D3DEF2] flex items-center justify-center flex-shrink-0 text-xs">
-                📷
-              </div>
-              <span class="text-sm font-medium text-[#444]">김민준 작가</span>
-              <span class="text-xs text-[#888]">
-                <span class="text-[#0097FF]">★</span>4.9 · 후기 87개
-              </span>
+          <div class="grid grid-cols-2 gap-4 mb-4">
+            <div>
+              <label class="text-sm font-medium text-[#444] mb-1.5 block">이름</label>
+              <input type="text" readonly
+                     th:value="${member?.name}"
+                     class="w-full bg-[#F0F0F0] border border-[#CCC] rounded-lg px-4 py-2.5 text-sm text-[#444] cursor-default">
             </div>
-
-            <!-- 플랜 상세 -->
-            <div class="flex flex-col gap-2 pb-4 mb-4 border-b border-[#CCC]">
-              <div class="flex items-center justify-between text-sm">
-                <span class="text-[#888]">⏱ 촬영 시간</span>
-                <span class="font-medium text-[#1A1A1A]">2시간</span>
-              </div>
-              <div class="flex items-center justify-between text-sm">
-                <span class="text-[#888]">🖼 원본 첫</span>
-                <span class="font-medium text-[#1A1A1A]">100장</span>
-              </div>
-              <div class="flex items-center justify-between text-sm">
-                <span class="text-[#888]">✨ 보정 첫</span>
-                <span class="font-medium text-[#1A1A1A]">20장</span>
-              </div>
-              <div class="flex items-center justify-between text-sm">
-                <span class="text-[#888]">📦 납품 기한</span>
-                <span class="font-medium text-[#1A1A1A]">3일 이내</span>
-              </div>
-            </div>
-
-            <!-- 예약 요약 -->
-            <div class="flex flex-col gap-2">
-              <div class="flex items-start justify-between text-sm gap-2">
-                <span class="text-[#888] flex-shrink-0">📅 촬영 날짜</span>
-                <span id="summaryDate" class="font-medium text-[#1A1A1A] text-right">2026.04.20 (일)</span>
-              </div>
-              <div class="flex items-center justify-between text-sm">
-                <span class="text-[#888]">🕐 시작 시간</span>
-                <span id="summaryTime" class="font-medium text-[#1A1A1A]">13:00</span>
-              </div>
-              <div class="flex items-start justify-between text-sm gap-2">
-                <span class="text-[#888] flex-shrink-0">📍 장소</span>
-                <span class="font-medium text-[#1A1A1A] text-right">서울 마포구 홍대입구역</span>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- 결제 금액 명세 -->
-        <div class="bg-white border border-[#CCC] rounded-2xl p-5">
-          <h3 class="text-sm font-semibold text-[#1A1A1A] mb-4">결제 금액 명세</h3>
-
-          <div class="flex flex-col gap-2.5 mb-4">
-            <div class="flex items-center justify-between text-sm">
-              <span class="text-[#444]">기본 패키지</span>
-              <span class="font-medium text-[#1A1A1A]">150,000원</span>
-            </div>
-            <div class="flex items-center justify-between text-sm">
-              <span class="text-[#444]">거리 추가요금 (1.2km)</span>
-              <span class="font-medium text-[#1D3CFF]">+1,200원</span>
+            <div>
+              <label class="text-sm font-medium text-[#444] mb-1.5 block">연락처</label>
+              <input type="tel" readonly
+                     th:value="${member?.phone}"
+                     class="w-full bg-[#F0F0F0] border border-[#CCC] rounded-lg px-4 py-2.5 text-sm text-[#444] cursor-default">
             </div>
           </div>
 
-          <div class="border-t border-[#CCC] pt-4">
-            <div class="flex items-center justify-between mb-1.5">
-              <span class="text-sm font-semibold text-[#1A1A1A]">총 결제금액</span>
-              <span id="totalPrice" class="text-lg font-bold text-[#1A1A1A]">
-                151,200 <span class="text-[#1D3CFF]">C</span>
-              </span>
-            </div>
-            <div class="flex items-center justify-between">
-              <span class="text-xs text-[#888]">결제 후 잔여 캐시</span>
-              <span id="remainingCash" class="text-sm font-medium text-[#888]">78,800 C</span>
-            </div>
+          <div class="mb-4">
+            <label class="text-sm font-medium text-[#444] mb-1.5 block">촬영 인원 <span class="text-red-400">*</span></label>
+            <select name="headCount"
+                    class="w-32 bg-[#F9FAFC] border border-[#CCC] rounded-lg px-4 py-2.5 text-sm text-[#1A1A1A] focus:outline-none focus:border-[#0097FF] focus:ring-1 focus:ring-[#0097FF] cursor-pointer">
+              <option value="1">1명</option>
+              <option value="2" selected>2명</option>
+              <option value="3">3명</option>
+              <option value="4">4명</option>
+              <option value="5">5명 이상</option>
+            </select>
           </div>
-        </div>
 
-        <!-- 예약 확정 버튼 -->
-        <button id="reserveBtn" type="button"
-                class="w-full bg-[#1D3CFF] hover:bg-[#1530E0] active:bg-[#1530E0] text-white font-bold py-4 rounded-xl transition-colors flex items-center justify-center gap-2 text-base">
-          <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
-          </svg>
-          <span id="reserveBtnLabel">151,200 캐시로 예약 확정</span>
-        </button>
+          <div>
+            <label class="text-sm font-medium text-[#444] mb-1.5 block">작가에게 전달할 요청사항</label>
+            <textarea name="memo" rows="4"
+                      placeholder="원하는 분위기, 특별한 요청사항, 촬영 컨셉 등을 자유롭게 적어주세요."
+                      class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-4 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] focus:outline-none focus:border-[#0097FF] focus:ring-1 focus:ring-[#0097FF] resize-none"></textarea>
+          </div>
+        </section>
 
-        <!-- 캐시 차감 안내 -->
-        <p class="text-xs text-[#888] text-center leading-relaxed px-2">
-          예약 확정 후 작가가 수락하면 캐시가 차감됩니다.<br>
-          예약 거절 시 전액 즉시 환불됩니다.
-        </p>
+        <!-- ⑤ 캐시 결제 (더미) -->
+        <section class="bg-white border border-[#CCC] rounded-2xl p-6">
+          <h2 class="text-base font-semibold text-[#1A1A1A] mb-4 flex items-center gap-2">
+            <span>💳</span><span>캐시 결제</span>
+          </h2>
 
-        <!-- 취소·환불 정책 -->
-        <div class="bg-white border border-[#CCC] rounded-xl p-4">
-          <h4 class="text-xs font-semibold text-[#444] mb-2.5">취소 · 환불 정책</h4>
-          <ul class="space-y-1.5">
-            <li class="text-xs text-[#888]">• 촬영 7일 전 취소: 전액 환불</li>
-            <li class="text-xs text-[#888]">• 촬영 3~7일 전 취소: 10% 수수료 차감</li>
-            <li class="text-xs text-[#888]">• 촬영 3일 이하만 취소: 30% 수수료 차감</li>
-            <li class="text-xs text-[#888]">• 작가 사정으로 인한 취소: 전액 즉시 환불</li>
-          </ul>
-        </div>
+          <div class="flex items-center justify-between bg-[#F9FAFC] border border-[#CCC] rounded-xl px-5 py-4 mb-4">
+            <div>
+              <p class="text-xs text-[#888] mb-0.5">보유 캐시</p>
+              <p class="text-xl font-bold text-[#1A1A1A]">
+                <span th:text="${member != null and member.cache != null ? #numbers.formatInteger(member.cache, 0, 'COMMA') : '0'}">0</span>
+                <span class="text-[#1D3CFF]">C</span>
+              </p>
+            </div>
+            <button type="button"
+                    class="text-sm font-semibold border border-[#1D3CFF] text-[#1D3CFF] px-4 py-2 rounded-lg hover:bg-[#1D3CFF] hover:text-white active:bg-[#1530E0] transition-colors">
+              + 캐시 충전
+            </button>
+          </div>
+
+          <div class="border-t border-[#CCC] pt-4 space-y-1.5">
+            <p class="text-xs text-[#888]">• 예약 거절 또는 작가 취소 시 전액 즉시 환불됩니다</p>
+            <p class="text-xs text-[#888]">• 촬영 7일 전 이전 취소: 전액 환불</p>
+            <p class="text-xs text-[#888]">• 캐시는 PICKKASSO 플랫폼 내에서만 사용 가능</p>
+          </div>
+        </section>
 
       </div>
-    </div> <!-- end 우측 -->
+      <!-- end 좌측 -->
 
-  </div>
+      <!-- ── 우측 요약 패널 ────────────────────────── -->
+      <div class="w-[340px] flex-shrink-0">
+        <div class="sticky top-[84px] flex flex-col gap-4">
+
+          <!-- 서비스 정보 카드 -->
+          <div class="bg-white border border-[#CCC] rounded-2xl overflow-hidden">
+            <!-- 썸네일 -->
+            <div class="relative w-full h-44 bg-gradient-to-br from-[#C8D8F0] to-[#8CA8D8] flex items-center justify-center">
+              <svg class="w-12 h-12 text-white opacity-60" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
+                      d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"/>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z"/>
+              </svg>
+              <span class="absolute top-3 left-3 bg-[#1D3CFF] text-white text-xs font-semibold px-3 py-1 rounded-full"
+                    th:text="${item.itemType.name() == 'IN' ? '스튜디오 촬영' : '방문 촬영'}">방문 촬영</span>
+            </div>
+
+            <div class="p-5">
+              <!-- 카테고리 + 제목 -->
+              <p class="text-xs font-medium text-[#0097FF] mb-1" th:text="${item.tag.name}">데이트 스냅</p>
+              <h3 class="text-sm font-bold text-[#1A1A1A] mb-3 leading-snug" th:text="${item.name}">서비스명</h3>
+
+              <!-- 작가 정보 -->
+              <div class="flex items-center gap-2 pb-4 mb-4 border-b border-[#CCC]">
+                <div class="w-8 h-8 rounded-full bg-[#D3DEF2] overflow-hidden flex items-center justify-center flex-shrink-0">
+                  <img th:if="${profile.imgUrl != null and !#strings.isEmpty(profile.imgUrl)}"
+                       th:src="${profile.imgUrl}" th:alt="${profile.nickname}"
+                       class="w-full h-full object-cover" loading="lazy">
+                  <span th:unless="${profile.imgUrl != null and !#strings.isEmpty(profile.imgUrl)}"
+                        class="text-sm">📷</span>
+                </div>
+                <span class="text-sm font-medium text-[#444]"
+                      th:text="${profile.nickname != null and !#strings.isEmpty(profile.nickname) ? profile.nickname + ' 작가' : '작가'}">작가</span>
+                <span class="text-xs text-[#888] ml-auto" th:if="${item.reviewCount > 0}">
+                  <span class="text-[#0097FF]">★</span>
+                  <span th:text="${#numbers.formatDecimal(item.avgScore / 100.0, 1, 1)}">4.9</span>
+                </span>
+              </div>
+
+              <!-- 플랜 상세 (선택된 플랜) -->
+              <div th:if="${selectedPlan != null}" class="flex flex-col gap-2 pb-4 mb-4 border-b border-[#CCC]">
+                <div class="text-xs font-semibold text-[#888] mb-1"
+                     th:text="${selectedPlan.name != null and !#strings.isEmpty(selectedPlan.name) ? selectedPlan.name : '기본 패키지'}">기본 패키지</div>
+                <div class="flex items-center justify-between text-sm">
+                  <span class="text-[#888]">⏱ 촬영 시간</span>
+                  <span class="font-medium text-[#1A1A1A]" th:text="${selectedPlan.shootingDuration} + '시간'">2시간</span>
+                </div>
+                <div class="flex items-center justify-between text-sm">
+                  <span class="text-[#888]">🖼 원본 컷</span>
+                  <span class="font-medium text-[#1A1A1A]"
+                        th:text="${selectedPlan.originalPhotoCount > 0 ? selectedPlan.originalPhotoCount + '장' : '미제공'}">100장</span>
+                </div>
+                <div class="flex items-center justify-between text-sm">
+                  <span class="text-[#888]">✨ 보정 컷</span>
+                  <span class="font-medium text-[#1A1A1A]" th:text="${selectedPlan.editedPhotoCount} + '장'">20장</span>
+                </div>
+                <div class="flex items-center justify-between text-sm">
+                  <span class="text-[#888]">📦 납품 기한</span>
+                  <span class="font-medium text-[#1A1A1A]" th:text="${selectedPlan.deliveryDays} + '일 이내'">3일 이내</span>
+                </div>
+              </div>
+
+              <!-- 예약 요약 (JS로 업데이트) -->
+              <div class="flex flex-col gap-2">
+                <div class="flex items-center justify-between text-sm">
+                  <span class="text-[#888]">📅 촬영 날짜</span>
+                  <span id="summaryDate" class="font-medium text-[#AAA]">날짜 미선택</span>
+                </div>
+                <div class="flex items-center justify-between text-sm">
+                  <span class="text-[#888]">🕐 시작 시간</span>
+                  <span id="summaryTime" class="font-medium text-[#AAA]">시간 미선택</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- 결제 금액 명세 -->
+          <div th:if="${selectedPlan != null}" class="bg-white border border-[#CCC] rounded-2xl p-5">
+            <h3 class="text-sm font-semibold text-[#1A1A1A] mb-4">결제 금액 명세</h3>
+
+            <div class="flex flex-col gap-2.5 mb-4">
+              <div class="flex items-center justify-between text-sm">
+                <span class="text-[#444]"
+                      th:text="${selectedPlan.name != null and !#strings.isEmpty(selectedPlan.name) ? selectedPlan.name : '기본 패키지'}">기본 패키지</span>
+                <span class="font-medium text-[#1A1A1A]"
+                      th:text="${#numbers.formatInteger(selectedPlan.price, 1, 'COMMA')} + '원'">0원</span>
+              </div>
+            </div>
+
+            <div class="border-t border-[#CCC] pt-4">
+              <div class="flex items-center justify-between mb-1.5">
+                <span class="text-sm font-semibold text-[#1A1A1A]">총 결제금액</span>
+                <span class="text-lg font-bold text-[#1D3CFF]">
+                  <span th:text="${#numbers.formatInteger(selectedPlan.price, 1, 'COMMA')}">0</span>
+                  <span class="text-base font-medium text-[#888]"> C</span>
+                </span>
+              </div>
+              <div class="flex items-center justify-between" th:if="${member != null and member.cache != null}">
+                <span class="text-xs text-[#888]">결제 후 잔여 캐시</span>
+                <span class="text-sm font-medium text-[#888]"
+                      th:text="${#numbers.formatInteger(member.cache - selectedPlan.price, 1, 'COMMA')} + ' C'">0 C</span>
+              </div>
+            </div>
+          </div>
+
+          <!-- 예약 확정 버튼 -->
+          <button type="submit" id="reserveBtn"
+                  onclick="return validateForm()"
+                  class="w-full bg-[#1D3CFF] hover:bg-[#1530E0] active:bg-[#1530E0] text-white font-bold py-4 rounded-xl transition-colors flex items-center justify-center gap-2 text-base">
+            <svg class="w-5 h-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2.5">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/>
+            </svg>
+            <span th:if="${selectedPlan != null}"
+                  th:text="${#numbers.formatInteger(selectedPlan.price, 1, 'COMMA')} + ' 캐시로 예약 신청'">예약 신청</span>
+            <span th:unless="${selectedPlan != null}">예약 신청하기</span>
+          </button>
+
+          <p class="text-xs text-[#888] text-center leading-relaxed px-2">
+            예약 신청 후 작가가 수락하면 캐시가 차감됩니다.<br>
+            예약 거절 시 전액 즉시 환불됩니다.
+          </p>
+
+          <!-- 취소·환불 정책 -->
+          <div class="bg-white border border-[#CCC] rounded-xl p-4">
+            <h4 class="text-xs font-semibold text-[#444] mb-2.5">취소 · 환불 정책</h4>
+            <div th:if="${item.cancellationPolicy != null and !#strings.isEmpty(item.cancellationPolicy)}"
+                 class="text-xs text-[#888] leading-6 whitespace-pre-line"
+                 th:text="${item.cancellationPolicy}"></div>
+            <ul th:unless="${item.cancellationPolicy != null and !#strings.isEmpty(item.cancellationPolicy)}"
+                class="space-y-1.5">
+              <li class="text-xs text-[#888]">• 촬영 7일 전 취소: 전액 환불</li>
+              <li class="text-xs text-[#888]">• 촬영 3~7일 전 취소: 10% 수수료 차감</li>
+              <li class="text-xs text-[#888]">• 촬영 3일 미만 취소: 30% 수수료 차감</li>
+              <li class="text-xs text-[#888]">• 작가 사정으로 인한 취소: 전액 즉시 환불</li>
+            </ul>
+          </div>
+
+        </div>
+      </div>
+      <!-- end 우측 -->
+
+    </div>
+  </form>
 </main>
 
-<!-- ══════════════════════════════════════════
-     JavaScript
-══════════════════════════════════════════ -->
-<script>
-  /* ── 상수 ── */
+<!-- ─── JavaScript ─────────────────────────────────────── -->
+<script th:inline="javascript">
+  /* 서버에서 받은 값 */
+  const MIN_LEAD_DAYS = /*[[${item.minBookingLeadTime}]]*/ 3;
+
   const MONTH_KO = ['1월','2월','3월','4월','5월','6월','7월','8월','9월','10월','11월','12월'];
   const DAY_KO   = ['일','월','화','수','목','금','토'];
 
-  /* ══ 캘린더 ══ */
-  const cal = { year: 2026, month: 3, sel: { y: 2026, m: 3, d: 20 } };
+  /* ── 캘린더 상태 ── */
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const minSelectableDate = new Date(today);
+  minSelectableDate.setDate(minSelectableDate.getDate() + MIN_LEAD_DAYS);
+
+  const cal = {
+    year: today.getFullYear(),
+    month: today.getMonth(),
+    sel: null
+  };
+
+  function isBeforeMinDate(year, month, day) {
+    const d = new Date(year, month, day);
+    return d < minSelectableDate;
+  }
 
   function renderCalendar() {
-    document.getElementById('calendarTitle').textContent = `${cal.year}년 ${MONTH_KO[cal.month]}`;
+    document.getElementById('calendarTitle').textContent =
+      `${cal.year}년 ${MONTH_KO[cal.month]}`;
 
-    const firstDay  = new Date(cal.year, cal.month, 1).getDay();
-    const lastDate  = new Date(cal.year, cal.month + 1, 0).getDate();
-    const prevLast  = new Date(cal.year, cal.month, 0).getDate();
-    const grid      = document.getElementById('calendarGrid');
-    grid.innerHTML  = '';
+    const firstDay = new Date(cal.year, cal.month, 1).getDay();
+    const lastDate = new Date(cal.year, cal.month + 1, 0).getDate();
+    const prevLast = new Date(cal.year, cal.month, 0).getDate();
+    const grid = document.getElementById('calendarGrid');
+    grid.innerHTML = '';
 
     /* 이전 달 잔여 일 */
     for (let i = firstDay - 1; i >= 0; i--) {
@@ -487,9 +470,19 @@
     /* 현재 달 */
     for (let d = 1; d <= lastDate; d++) {
       const dow = new Date(cal.year, cal.month, d).getDay();
-      const isSel = (cal.sel.y === cal.year && cal.sel.m === cal.month && cal.sel.d === d);
-      const cls = isSel ? 'selected' : (dow === 0 ? 'sun' : dow === 6 ? 'sat' : 'normal');
-      appendCell(grid, d, cls, isSel ? null : d);
+      const isSel = cal.sel &&
+        cal.sel.y === cal.year && cal.sel.m === cal.month && cal.sel.d === d;
+
+      let cls;
+      if (isSel) {
+        cls = 'selected';
+      } else if (isBeforeMinDate(cal.year, cal.month, d)) {
+        cls = 'disabled';
+      } else {
+        cls = dow === 0 ? 'sun' : dow === 6 ? 'sat' : 'normal';
+      }
+
+      appendCell(grid, d, cls, (cls === 'disabled' || isSel) ? null : d);
     }
 
     /* 다음 달 채우기 */
@@ -518,11 +511,17 @@
   function selectDate(d) {
     cal.sel = { y: cal.year, m: cal.month, d };
     renderCalendar();
-    const date = new Date(cal.sel.y, cal.sel.m, cal.sel.d);
+
     const mm = String(cal.sel.m + 1).padStart(2, '0');
     const dd = String(cal.sel.d).padStart(2, '0');
+    const dateStr = `${cal.sel.y}-${mm}-${dd}`;
+    document.getElementById('scheduledDate').value = dateStr;
+
+    const date = new Date(cal.sel.y, cal.sel.m, cal.sel.d);
     document.getElementById('summaryDate').textContent =
       `${cal.sel.y}.${mm}.${dd} (${DAY_KO[date.getDay()]})`;
+    document.getElementById('summaryDate').classList.remove('text-[#AAA]');
+    document.getElementById('summaryDate').classList.add('text-[#1A1A1A]');
   }
 
   document.getElementById('prevMonth').addEventListener('click', () => {
@@ -536,38 +535,42 @@
 
   renderCalendar();
 
-  /* ══ 시간 슬롯 ══ */
-  const TIME_DATA = [
-    { t: '09:00', ok: false },
-    { t: '10:00', ok: true  },
-    { t: '11:00', ok: true  },
-    { t: '12:00', ok: true  },
-    { t: '13:00', ok: true  },
-    { t: '14:00', ok: true  },
-    { t: '15:00', ok: false },
-    { t: '16:00', ok: true  },
-    { t: '17:00', ok: true  },
-    { t: '18:00', ok: true  },
-    { t: '19:00', ok: false },
-    { t: '20:00', ok: true  },
+  /* ── 시간 슬롯 ── */
+  const TIME_SLOTS = [
+    { t: '09:00', h: 9,  ok: true },
+    { t: '10:00', h: 10, ok: true },
+    { t: '11:00', h: 11, ok: true },
+    { t: '12:00', h: 12, ok: true },
+    { t: '13:00', h: 13, ok: true },
+    { t: '14:00', h: 14, ok: true },
+    { t: '15:00', h: 15, ok: true },
+    { t: '16:00', h: 16, ok: true },
+    { t: '17:00', h: 17, ok: true },
+    { t: '18:00', h: 18, ok: true },
+    { t: '19:00', h: 19, ok: true },
+    { t: '20:00', h: 20, ok: true },
   ];
 
-  let selectedTime = '13:00';
+  let selectedHour = null;
 
   function renderTimeSlots() {
     const container = document.getElementById('timeSlots');
     container.innerHTML = '';
-    TIME_DATA.forEach(({ t, ok }) => {
+    TIME_SLOTS.forEach(({ t, h, ok }) => {
       const btn = document.createElement('button');
       btn.type = 'button';
       btn.textContent = t;
-      btn.className = 'time-btn' + (t === selectedTime ? ' time-selected' : '');
+      btn.className = 'time-btn' + (h === selectedHour ? ' time-selected' : '');
       btn.disabled = !ok;
-      if (ok && t !== selectedTime) {
+      if (ok) {
         btn.addEventListener('click', () => {
-          selectedTime = t;
+          selectedHour = h;
+          document.getElementById('scheduledHour').value = h;
+          const summaryTime = document.getElementById('summaryTime');
+          summaryTime.textContent = t;
+          summaryTime.classList.remove('text-[#AAA]');
+          summaryTime.classList.add('text-[#1A1A1A]');
           renderTimeSlots();
-          document.getElementById('summaryTime').textContent = t;
         });
       }
       container.appendChild(btn);
@@ -576,6 +579,26 @@
 
   renderTimeSlots();
 
+  /* ── 폼 유효성 검사 ── */
+  function validateForm() {
+    const date = document.getElementById('scheduledDate').value;
+    const hour = document.getElementById('scheduledHour').value;
+    const address = document.getElementById('addressInput').value.trim();
+
+    if (!date) {
+      alert('촬영 날짜를 선택해 주세요.');
+      return false;
+    }
+    if (!hour) {
+      alert('촬영 시작 시간을 선택해 주세요.');
+      return false;
+    }
+    if (!address) {
+      alert('촬영 장소를 입력해 주세요.');
+      return false;
+    }
+    return true;
+  }
 </script>
 
 </body>


### PR DESCRIPTION
## 작업 내용
- 작가 대시보드 데이터베이스 연결
- 개발 환경에서 확인 가능하도록 예약 시더 추가

## 변경 사항
- 작가 대시보드의 예약 관련 UI를 `t_order` 조회 결과와 연결
- 오늘 예약 수, 승인 대기 수, 오늘 일정, 주간 예약 현황 캘린더를 DB 데이터로 렌더링
- 예약 수락/거절 동작을 DB 상태 변경과 연결
- `dev` 프로필에서 테스트용 작가/회원/예약 데이터를 생성하는 시더 추가
- 주간 예약 현황 캘린더의 이전 주/다음 주/오늘 이동 기능 구현

## 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 작가 대시보드 페이지 렌더링 확인
- [x] 캘린더 정상 동작 확인
- [x] 예약 수락 동작 확인
- [x] 정산 페이지 동작 확인
- [x] 후기 페이지 목업 구현

## 확인 방법
- IntelliJ Run Configuration(구성 편집)에서 Active Profile을 `dev`로 설정
- `dev_photo / password1a` 계정으로 로그인
- 작가 대시보드에서 예약 데이터 및 캘린더 동작 확인

## 참고
- dev 프로필에서만 시더가 동작합니다.