### PR TITLE
fix: TEXT 대신 TINYTEXT가 반영되던 오류 수정

### DIFF
--- a/src/main/java/com/pickkasso/pickkasso/item/entity/Item.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/entity/Item.java
@@ -34,15 +34,15 @@ public class Item extends Region {
     private String name;
 
     @Lob
-    @Column(name = "description", nullable = false)
+    @Column(name = "description", nullable = false, columnDefinition = "TEXT")
     private String description;
 
     @Lob
-    @Column(name = "includes")
+    @Column(name = "includes", columnDefinition = "TEXT")
     private String includes;
 
     @Lob
-    @Column(name = "excludes")
+    @Column(name = "excludes", columnDefinition = "TEXT")
     private String excludes;
 
     @Column(name = "item_type", nullable = false)
@@ -66,7 +66,7 @@ public class Item extends Region {
     private Integer minBookingLeadTime;
 
     @Lob
-    @Column(name = "cancellation_policy")
+    @Column(name = "cancellation_policy", columnDefinition = "TEXT")
     private String cancellationPolicy;
 
     // TODO: createdAt 등은 나중에 따로 서브테이블로 관리해야 한다. 지금은 구현을 위해

--- a/src/main/java/com/pickkasso/pickkasso/item/entity/ItemNotice.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/entity/ItemNotice.java
@@ -22,7 +22,7 @@ public class ItemNotice {
     private Integer noticeOrder;
 
     @Lob
-    @Column(name = "description")
+    @Column(name = "description", columnDefinition = "TEXT")
     private String description;
 
     private ItemNotice(

--- a/src/main/java/com/pickkasso/pickkasso/user/entity/PhotographerProfile.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/entity/PhotographerProfile.java
@@ -30,7 +30,7 @@ public class PhotographerProfile {
     private String nickname;
 
     @Lob
-    @Column(name = "intro", nullable = false)
+    @Column(name = "intro", nullable = false, columnDefinition = "TEXT")
     private String intro;
 
     @JdbcTypeCode(SqlTypes.JSON)

--- a/src/main/java/com/pickkasso/pickkasso/user/entity/Portfolio.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/entity/Portfolio.java
@@ -28,7 +28,7 @@ public class Portfolio {
     private String name;
 
     @Lob
-    @Column(name = "description")
+    @Column(name = "description", columnDefinition = "TEXT")
     private String description;
 
     @Enumerated(EnumType.STRING)


### PR DESCRIPTION
## 작업 내용
- Item, ItemNotice, PhotographerProfile, Portfolio의 Lob에 columnDefinition = "TEXT" 추가

## 변경 사항
- Item, ItemNotice, PhotographerProfile, Portfolio Table의 TINYTEXT -> TEXT
  - DB를 지우는 것이 아니라면, 수동으로 이를 바꿔주세요. 현재의 변경은 코드에서의 변경입니다.