### PR TITLE
fix: 마이페이지 500 에러 수정

### DIFF
--- a/src/main/java/com/pickkasso/pickkasso/user/controller/MyPageController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/MyPageController.java
@@ -3,10 +3,14 @@ package com.pickkasso.pickkasso.user.controller;
 import com.pickkasso.pickkasso.user.dto.PasswordChangeDto;
 import com.pickkasso.pickkasso.user.entity.Account;
 import com.pickkasso.pickkasso.user.entity.Member;
+import com.pickkasso.pickkasso.user.entity.Photographer;
+import com.pickkasso.pickkasso.user.entity.Role;
 import com.pickkasso.pickkasso.user.repository.AccountRepository;
 import com.pickkasso.pickkasso.user.repository.MemberRepository;
+import com.pickkasso.pickkasso.user.repository.PhotographerRepository;
 import com.pickkasso.pickkasso.user.service.AccountService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Controller;
@@ -19,6 +23,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 @RequestMapping("/member/mypage")
 public class MyPageController {
 
+    private final PhotographerRepository photographerRepository;
     private final MemberRepository memberRepository;
     private final AccountRepository accountRepository;
     private final PasswordEncoder passwordEncoder;
@@ -42,7 +47,17 @@ public class MyPageController {
 
     @GetMapping("/profile")
     public String profile(Authentication auth, Model model) {
-        model.addAttribute("member", getCurrentMember(auth));
+        Account account = accountRepository.findByUsername(auth.getName());
+
+        if (account.getRole() == Role.PHOTOGRAPHER) {
+            // 작가라면 작가 테이블에서 조회
+            Photographer photographer = photographerRepository.findByAccount(account);
+            model.addAttribute("member", photographer); // HTML에서 'member'라는 이름을 공통으로 쓴다면 이름을 맞춰줍니다.
+        } else {
+            // 일반 회원이라면 멤버 테이블에서 조회
+            Member member = memberRepository.findByAccount(account);
+            model.addAttribute("member", member);
+        }
         model.addAttribute("activeTab", "profile");
         return "user/mypage/profile";
     }
@@ -72,11 +87,6 @@ public class MyPageController {
 
         redirectAttributes.addFlashAttribute("success", true);
         return "redirect:/member/mypage/profile";
-    }
-
-    @GetMapping("/member/mypage/profile")
-    public String getProfile(Authentication auth, Model model) {
-        return "user/mypage/profile"; // flash attribute가 model에 자동으로 담김
     }
 
     @GetMapping("/photographer/{photographerId}/profile")

--- a/src/main/java/com/pickkasso/pickkasso/user/repository/MemberRepository.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/repository/MemberRepository.java
@@ -4,11 +4,13 @@ package com.pickkasso.pickkasso.user.repository;
 import com.pickkasso.pickkasso.user.entity.Account;
 import com.pickkasso.pickkasso.user.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByNameAndEmail(String name, String email);
     Optional<Member> findByEmail(String email);
-    Member findByAccount(Account account);
+    Member findByAccount(Account account);// account_id로 조회
 }

--- a/src/main/java/com/pickkasso/pickkasso/user/repository/PhotographerRepository.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/repository/PhotographerRepository.java
@@ -1,8 +1,10 @@
 package com.pickkasso.pickkasso.user.repository;
 
+import com.pickkasso.pickkasso.user.entity.Account;
 import com.pickkasso.pickkasso.user.entity.Photographer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PhotographerRepository extends JpaRepository<Photographer, Long> {
     Photographer findByAccountUsername(String username);
+    Photographer findByAccount(Account account);
 }

--- a/src/main/java/com/pickkasso/pickkasso/user/service/SignupService.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/service/SignupService.java
@@ -10,6 +10,7 @@ import com.pickkasso.pickkasso.user.repository.MemberRepository;
 import com.pickkasso.pickkasso.user.repository.PhotographerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +21,7 @@ public class SignupService {
     private final PhotographerRepository photographerRepository;
 
 
+    @Transactional
     public void signup(SignupDto dto) {
 
         if (!dto.getPassword().matches("^(?=.*[a-z])(?=.*\\d).{8,30}$")) {

--- a/src/main/resources/templates/fragments/mypage-sidebar.html
+++ b/src/main/resources/templates/fragments/mypage-sidebar.html
@@ -6,7 +6,7 @@
   <div class="bg-white border border-[#CCC] rounded-2xl p-6">
 
     <!-- 유저 정보 -->
-    <div th:if="${member != null}" class="flex flex-col items-center text-center pb-5 mb-5 border-b border-[#CCC]">
+    <div class="flex flex-col items-center text-center pb-5 mb-5 border-b border-[#CCC]">
       <div class="w-16 h-16 rounded-full bg-[#D3DEF2] flex items-center justify-center text-2xl mb-3">
         👤
       </div>

--- a/src/main/resources/templates/fragments/mypage-sidebar.html
+++ b/src/main/resources/templates/fragments/mypage-sidebar.html
@@ -6,7 +6,7 @@
   <div class="bg-white border border-[#CCC] rounded-2xl p-6">
 
     <!-- 유저 정보 -->
-    <div class="flex flex-col items-center text-center pb-5 mb-5 border-b border-[#CCC]">
+    <div th:if="${member != null}" class="flex flex-col items-center text-center pb-5 mb-5 border-b border-[#CCC]">
       <div class="w-16 h-16 rounded-full bg-[#D3DEF2] flex items-center justify-center text-2xl mb-3">
         👤
       </div>


### PR DESCRIPTION
## 작업 내용
- 마이페이지 진입 시 발생하던 500 에러 수정
- 회원/작가 역할에 따른 조회 로직 분기 처리 추가

## 변경 사항
- SignupService
  - @Transactional 어노테이션 추가

- MyPageController
  - 불필요한 @GetMapping("/member/mypage/profile") 제거
  - @GetMapping("/profile")에서 회원/작가(role)에 따른 분기 처리 추가
  - member, photographer 객체를 상황에 맞게 model에 전달하도록 수정

## 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 회원 로그인 시 마이페이지 정상 렌더링 확인
- [x] 작가 로그인 시 마이페이지 정상 렌더링 확인
- [x] 사이드바 및 기본 정보 영역 정상 출력 확인

## 참고
- 기존 코드에서는 일부 상황에서 member 객체가 null로 전달되며 500 에러가 발생할 수 있었음
- URL 매핑 구조와 role 분기 처리를 수정하여 안정적으로 동작하도록 개선
- 트랜잭션 처리를 추가하여 조회 흐름을 보완함