### PR TITLE
Feat: AI PICK 추천에 예약 날짜/시간 가용성 필터 연동

### DIFF
--- a/src/main/java/com/pickkasso/pickkasso/global/controller/AiPickController.java
+++ b/src/main/java/com/pickkasso/pickkasso/global/controller/AiPickController.java
@@ -227,14 +227,24 @@ public class AiPickController {
     private boolean isRecommendAsIsAnswer(String query) {
         if (query == null) return false;
         String normalized = query.replaceAll("\\s+", "").toLowerCase();
+        if (normalized.equals("추천")
+            || normalized.equals("추천해")
+            || normalized.equals("추천해줘")
+            || normalized.equals("추천해주세요")
+            || normalized.equals("추천해줘요")) {
+            return true;
+        }
         return normalized.contains("이대로추천")
             || normalized.contains("바로추천")
             || normalized.contains("바로추천해줘")
+            || normalized.contains("바로추천해주세요")
             || normalized.contains("바로보여줘")
             || normalized.contains("이정도로")
             || normalized.contains("이정도만")
             || normalized.contains("그냥추천")
             || normalized.contains("걍추천")
+            || normalized.contains("추천만")
+            || normalized.contains("추천해")
             || normalized.contains("더안채울")
             || normalized.contains("채우기싫")
             || normalized.contains("조건없이추천");

--- a/src/main/java/com/pickkasso/pickkasso/global/service/AiPickRecommendationService.java
+++ b/src/main/java/com/pickkasso/pickkasso/global/service/AiPickRecommendationService.java
@@ -7,6 +7,9 @@ import com.pickkasso.pickkasso.global.dto.ChatMessageDto;
 import com.pickkasso.pickkasso.item.entity.Item;
 import com.pickkasso.pickkasso.item.repository.AiItemQuerySpec;
 import com.pickkasso.pickkasso.item.repository.ItemRepository;
+import com.pickkasso.pickkasso.user.entity.Reservation;
+import com.pickkasso.pickkasso.user.entity.ReservationStatus;
+import com.pickkasso.pickkasso.user.repository.ReservationRepository;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +23,8 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -45,6 +50,8 @@ public class AiPickRecommendationService {
     private static final Pattern MONTH_DAY_KO_PATTERN = Pattern.compile("(\\d{1,2})\\s*월\\s*(\\d{1,2})\\s*일");
     private static final Pattern MONTH_DAY_SLASH_PATTERN = Pattern.compile("(\\d{1,2})\\s*/\\s*(\\d{1,2})(?:\\s*일)?");
     private static final Pattern MONTH_DAY_DASH_PATTERN = Pattern.compile("(\\d{1,2})\\s*-\\s*(\\d{1,2})(?:\\s*일)?");
+    private static final Pattern HOUR_PATTERN = Pattern.compile("(오전|오후)?\\s*(\\d{1,2})\\s*시");
+    private static final Pattern HOUR_COLON_PATTERN = Pattern.compile("\\b(\\d{1,2})\\s*:\\s*([0-5]\\d)\\b");
     private static final Map<String, List<String>> NEARBY_REGIONS = Map.ofEntries(
         Map.entry("홍대", List.of("홍대", "홍대입구", "연남", "연남동", "합정", "합정동", "상수", "상수동", "망원", "망원동", "서교동", "동교동", "마포")),
         Map.entry("강남", List.of("강남", "강남역", "신논현", "역삼", "역삼동", "선릉", "삼성", "삼성동", "논현", "논현동", "신사", "신사동", "압구정")),
@@ -60,8 +67,13 @@ public class AiPickRecommendationService {
             "강서", "구로", "금천", "영등포", "동작", "관악"
         ))
     );
+    private static final Set<ReservationStatus> BLOCKING_RESERVATION_STATUSES = Set.of(
+        ReservationStatus.PENDING,
+        ReservationStatus.CONFIRMED
+    );
 
     private final ItemRepository itemRepository;
+    private final ReservationRepository reservationRepository;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final HttpClient httpClient = HttpClient.newHttpClient();
 
@@ -81,7 +93,9 @@ public class AiPickRecommendationService {
     public AiPickResultDto recommend(String rawQuery, boolean expandNearby, Set<Long> excludedItemIds) {
         AiPickQueryDto parsed = parseQueryWithGeminiOrRule(rawQuery);
         List<Item> candidates = loadCandidatesFromDb(parsed, expandNearby);
+        candidates = filterUnavailableByRequestedDateTime(candidates, parsed);
         candidates = enrichCandidatesToTarget(candidates, parsed);
+        candidates = filterUnavailableByRequestedDateTime(candidates, parsed);
         candidates = excludeItems(candidates, excludedItemIds);
         List<ScoredItem> ranked = rankCandidates(candidates, parsed);
         List<AiRecommendationDto> recommendations = mapRecommendations(ranked, parsed);
@@ -101,6 +115,114 @@ public class AiPickRecommendationService {
             .filter(item -> item != null && item.getId() != null)
             .filter(item -> !excludedItemIds.contains(item.getId()))
             .toList();
+    }
+
+    private List<Item> filterUnavailableByRequestedDateTime(List<Item> candidates, AiPickQueryDto parsed) {
+        if (candidates == null || candidates.isEmpty() || !hasText(parsed.requestedDate())) {
+            return candidates == null ? List.of() : candidates;
+        }
+        LocalDate requestedDate;
+        try {
+            requestedDate = LocalDate.parse(parsed.requestedDate());
+        } catch (Exception ignored) {
+            return candidates;
+        }
+
+        List<Long> photographerIds = candidates.stream()
+            .map(item -> item.getPhotographer() == null ? null : item.getPhotographer().getId())
+            .filter(id -> id != null)
+            .distinct()
+            .toList();
+        if (photographerIds.isEmpty()) {
+            return candidates;
+        }
+
+        // DB 시간대(UTC 저장)와 사용자 시간대(Asia/Seoul) 차이를 흡수하기 위해
+        // 조회 범위를 넉넉히 잡고, 이후 KST 기준 날짜/시간으로 한 번 더 필터링한다.
+        LocalDateTime dayStart = requestedDate.minusDays(1).atStartOfDay();
+        LocalDateTime dayEnd = requestedDate.plusDays(2).atStartOfDay();
+        List<Reservation> dayReservations = reservationRepository.findByPhotographerIdsInRange(
+            photographerIds, dayStart, dayEnd, BLOCKING_RESERVATION_STATUSES
+        );
+        if (dayReservations.isEmpty()) {
+            return candidates;
+        }
+        List<Reservation> sameDayReservations = dayReservations.stream()
+            .filter(reservation -> reservation.getScheduledAt().toLocalDate().equals(requestedDate))
+            .toList();
+        if (sameDayReservations.isEmpty()) {
+            return candidates;
+        }
+
+        Integer requestedHour = parseRequestedHour(parsed.rawQuery());
+        if (requestedHour == null) {
+            // 시간 미입력 시에는 작가/상품을 통째로 제외하지 않는다.
+            // (같은 날짜라도 다른 시간 슬롯이 비어 있을 수 있음)
+            return candidates;
+        }
+
+        LocalDateTime requestedStart = requestedDate.atTime(LocalTime.of(requestedHour, 0));
+        LocalDateTime requestedEnd = requestedStart.plusHours(1);
+        Set<Long> blockedPhotographerIds = new HashSet<>();
+        for (Reservation reservation : sameDayReservations) {
+            LocalDateTime reservationStart = reservation.getScheduledAt();
+            int durationMinutes = reservation.getDurationMinutes() == null ? 60 : reservation.getDurationMinutes();
+            LocalDateTime reservationEnd = reservationStart.plusMinutes(durationMinutes);
+            if (requestedStart.isBefore(reservationEnd) && requestedEnd.isAfter(reservationStart)) {
+                blockedPhotographerIds.add(reservation.getPhotographer().getId());
+            }
+        }
+
+        if (blockedPhotographerIds.isEmpty()) {
+            return candidates;
+        }
+        return candidates.stream()
+            .filter(item -> item != null && item.getPhotographer() != null && item.getPhotographer().getId() != null)
+            .filter(item -> !blockedPhotographerIds.contains(item.getPhotographer().getId()))
+            .toList();
+    }
+
+    private Integer parseRequestedHour(String rawQuery) {
+        if (!hasText(rawQuery)) {
+            return null;
+        }
+        Matcher colonMatcher = HOUR_COLON_PATTERN.matcher(rawQuery);
+        if (colonMatcher.find()) {
+            int hour;
+            try {
+                hour = Integer.parseInt(colonMatcher.group(1));
+            } catch (NumberFormatException ignored) {
+                return null;
+            }
+            if (hour < 0 || hour > 23) {
+                return null;
+            }
+            return hour;
+        }
+        Matcher matcher = HOUR_PATTERN.matcher(rawQuery);
+        if (!matcher.find()) {
+            return null;
+        }
+        int hour;
+        try {
+            hour = Integer.parseInt(matcher.group(2));
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+        if (hour < 0 || hour > 24) {
+            return null;
+        }
+        String meridiem = matcher.group(1);
+        if ("오전".equals(meridiem)) {
+            return hour == 12 ? 0 : hour;
+        }
+        if ("오후".equals(meridiem)) {
+            return hour == 12 ? 12 : hour + 12;
+        }
+        if (hour == 24) {
+            return 0;
+        }
+        return hour;
     }
 
     private AiPickQueryDto parseQueryWithGeminiOrRule(String rawQuery) {

--- a/src/main/java/com/pickkasso/pickkasso/user/repository/ReservationRepository.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/repository/ReservationRepository.java
@@ -43,6 +43,34 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
 
     @Query("""
             select r from Reservation r
+              join fetch r.item i
+            where i.id in :itemIds
+              and r.scheduledAt >= :from
+              and r.scheduledAt < :to
+              and r.status in :statuses
+            """)
+    List<Reservation> findByItemIdsInRange(
+            @Param("itemIds") Collection<Long> itemIds,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to,
+            @Param("statuses") Collection<ReservationStatus> statuses);
+
+    @Query("""
+            select r from Reservation r
+              join fetch r.photographer p
+            where p.id in :photographerIds
+              and r.scheduledAt >= :from
+              and r.scheduledAt < :to
+              and r.status in :statuses
+            """)
+    List<Reservation> findByPhotographerIdsInRange(
+            @Param("photographerIds") Collection<Long> photographerIds,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to,
+            @Param("statuses") Collection<ReservationStatus> statuses);
+
+    @Query("""
+            select r from Reservation r
               join fetch r.member m
               join fetch r.item i
             where r.photographer.id = :photographerId


### PR DESCRIPTION
## 작업 내용
- AI PICK 추천에 예약 가용성 필터를 연동해, 날짜/시간 입력 시 `PENDING`·`CONFIRMED` 예약 슬롯과 겹치는 작가를 추천 후보에서 제외했습니다.
- 시간 미입력 시에는 날짜만으로 작가를 통째로 제외하지 않도록 정책을 정리해, 같은 날짜의 다른 가능 시간대 추천은 유지했습니다.
- 조건 부족 단계에서 `추천`, `추천해줘`, `추천해주세요` 등 간단 입력도 “현재 정보로 바로 추천” 의도로 인식하도록 문구 인식을 확장했습니다.

## 변경 사항
- `AiPickRecommendationService`
  - 예약 시간 슬롯 충돌 기반 필터 로직 추가/보정
  - 시간 입력 형식 파싱 확장(`오후 1시`, `13:00` 등)
  - 시간대 보정 이슈 수정(이중 보정 제거)
- `ReservationRepository`
  - 작가 ID + 기간 + 상태 기준 예약 조회 쿼리 추가
- `AiPickController`
  - 즉시 추천 의도 문구 인식 범위 확장

## 테스트
- [x] 날짜+시간 충돌 케이스에서 해당 작가가 추천에서 제외되는지 확인
- [x] 같은 날짜 비충돌 시간에서는 추천이 정상 노출되는지 확인
- [x] 시간 미입력(날짜만) 시 추천을 통째로 막지 않는지 확인
- [x] 로컬에서 정상 동작 확인
- [x] 관련 페이지 렌더링 확인

## 참고
- #64 