### PR TITLE
feat: 작가 서비스 수정 기능 추가 및 상세 페이지 권한별 UI 적용

### DIFF
--- a/src/main/java/com/pickkasso/pickkasso/item/controller/ItemController.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/controller/ItemController.java
@@ -9,6 +9,7 @@ import com.pickkasso.pickkasso.item.entity.Item;
 import com.pickkasso.pickkasso.item.service.ItemService;
 import com.pickkasso.pickkasso.user.service.PhotographerProfileService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -79,11 +80,23 @@ public class ItemController {
     }
 
     @GetMapping("/item/{id}")
-    public String itemDetail(@PathVariable Long id, Model model) {
+    public String itemDetail(@PathVariable Long id, Model model, Authentication authentication) {
         Item item = itemService.getItemById(id);
         Long photographerId = item.getPhotographer().getId();
         model.addAttribute("item", item);
         model.addAttribute("profile", photographerProfileService.getProfileForm(photographerId));
+        model.addAttribute("canEditService", isOwnerPhotographer(item, authentication));
         return "photographer/service-detail";
+    }
+
+    private boolean isOwnerPhotographer(Item item, Authentication authentication) {
+        if (authentication == null || authentication.getName() == null) {
+            return false;
+        }
+        if (authentication.getAuthorities().stream().noneMatch(a -> "ROLE_PHOTOGRAPHER".equals(a.getAuthority()))) {
+            return false;
+        }
+        String ownerUsername = item.getPhotographer().getAccount().getUsername();
+        return ownerUsername != null && ownerUsername.equals(authentication.getName());
     }
 }

--- a/src/main/java/com/pickkasso/pickkasso/item/controller/ServiceRegisterController.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/controller/ServiceRegisterController.java
@@ -2,10 +2,16 @@ package com.pickkasso.pickkasso.item.controller;
 
 import com.pickkasso.pickkasso.global.tag.TagService;
 import com.pickkasso.pickkasso.item.dto.ItemRegisterRequest;
+import com.pickkasso.pickkasso.item.dto.PlanRegisterRequest;
 import com.pickkasso.pickkasso.item.entity.Item;
+import com.pickkasso.pickkasso.item.entity.Plan;
 import com.pickkasso.pickkasso.item.service.ItemService;
+import com.pickkasso.pickkasso.user.entity.Account;
+import com.pickkasso.pickkasso.user.entity.Role;
+import com.pickkasso.pickkasso.user.repository.AccountRepository;
 import com.pickkasso.pickkasso.user.service.PhotographerProfileService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,17 +20,23 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.server.ResponseStatusException;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
+import org.springframework.http.HttpStatus;
 
 @Controller
 @RequiredArgsConstructor
-@RequestMapping("/photographer/{photographerId}/service")
+@RequestMapping("/photographer/{photographerId}")
 public class ServiceRegisterController {
 
     private final ItemService itemService;
     private final TagService tagService;
     private final PhotographerProfileService photographerProfileService;
+    private final AccountRepository accountRepository;
 
     private static final Map<String, String> CATEGORY_EMOJIS = Map.ofEntries(
         Map.entry("데이트스냅", "🌸"),
@@ -49,40 +61,148 @@ public class ServiceRegisterController {
         Map.entry("공연", "🎭")
     );
 
-    @GetMapping("/{itemId}")
+    @GetMapping("/service/{itemId}")
     public String serviceDetail(
         @PathVariable Long photographerId,
         @PathVariable Long itemId,
-        Model model) {
+        Model model,
+        Authentication authentication) {
 
         Item item = itemService.getItemById(itemId);
         model.addAttribute("item", item);
         model.addAttribute("profile", photographerProfileService.getProfileForm(photographerId));
+        model.addAttribute("canEditService", isOwnerPhotographer(item, authentication));
         return "photographer/service-detail";
     }
 
-    @GetMapping("/new")
+    @GetMapping("/service/new")
     public String serviceRegisterForm(@PathVariable Long photographerId, Model model) {
         model.addAttribute("photographerId", photographerId);
         model.addAttribute("tagList", tagService.findAllTagReference());
         model.addAttribute("categoryEmojis", CATEGORY_EMOJIS);
         model.addAttribute("itemRegisterRequest", new ItemRegisterRequest());
+        model.addAttribute("formAction", "/photographer/" + photographerId + "/service/new");
         return "photographer/service-register";
     }
 
-    @PostMapping("/new")
+    @PostMapping("/service/new")
     public String registerService(
         @PathVariable Long photographerId,
         @ModelAttribute ItemRegisterRequest itemRegisterRequest,
         RedirectAttributes redirectAttributes) {
 
         try {
-            Long itemId = itemService.registerItem(photographerId, itemRegisterRequest);
+            itemService.registerItem(photographerId, itemRegisterRequest);
             redirectAttributes.addFlashAttribute("successMessage", "서비스가 등록되었습니다.");
             return "redirect:/photographer/" + photographerId + "/profile";
         } catch (Exception e) {
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
             return "redirect:/photographer/" + photographerId + "/service/new";
         }
+    }
+
+    @GetMapping("/item/{itemId}/edit")
+    public String serviceEditForm(
+        @PathVariable Long photographerId,
+        @PathVariable Long itemId,
+        Authentication authentication,
+        Model model) {
+        ensurePhotographerOwner(authentication, photographerId);
+
+        Item item = itemService.getItemById(itemId);
+        if (!item.getPhotographer().getId().equals(photographerId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인 서비스만 수정할 수 있습니다.");
+        }
+
+        ItemRegisterRequest itemRequest = toItemRegisterRequest(item);
+        populateEditFormModel(model, photographerId, itemId, itemRequest);
+        return "photographer/service-edit";
+    }
+
+    @PostMapping("/item/{itemId}/edit")
+    public String editService(
+        @PathVariable Long photographerId,
+        @PathVariable Long itemId,
+        Authentication authentication,
+        @ModelAttribute ItemRegisterRequest itemRegisterRequest,
+        Model model,
+        RedirectAttributes redirectAttributes) {
+        ensurePhotographerOwner(authentication, photographerId);
+
+        try {
+            itemService.updateItem(photographerId, itemId, itemRegisterRequest);
+            redirectAttributes.addFlashAttribute("successMessage", "서비스가 수정되었습니다.");
+            return "redirect:/item/" + itemId;
+        } catch (Exception e) {
+            model.addAttribute("errorMessage", e.getMessage());
+            populateEditFormModel(model, photographerId, itemId, itemRegisterRequest);
+            return "photographer/service-edit";
+        }
+    }
+
+    private void populateEditFormModel(
+        Model model,
+        Long photographerId,
+        Long itemId,
+        ItemRegisterRequest itemRequest
+    ) {
+        model.addAttribute("photographerId", photographerId);
+        model.addAttribute("tagList", tagService.findAllTagReference());
+        model.addAttribute("categoryEmojis", CATEGORY_EMOJIS);
+        model.addAttribute("itemRequest", itemRequest);
+        model.addAttribute("itemRegisterRequest", itemRequest);
+        model.addAttribute("formAction", "/photographer/" + photographerId + "/item/" + itemId + "/edit");
+    }
+
+    private void ensurePhotographerOwner(Authentication authentication, Long photographerId) {
+        if (authentication == null || authentication.getName() == null) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+        }
+        Account account = accountRepository.findByUsername(authentication.getName());
+        if (account == null || account.getRole() != Role.PHOTOGRAPHER || !photographerId.equals(account.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인 계정으로만 수정할 수 있습니다.");
+        }
+    }
+
+    private boolean isOwnerPhotographer(Item item, Authentication authentication) {
+        if (authentication == null || authentication.getName() == null) {
+            return false;
+        }
+        if (authentication.getAuthorities().stream().noneMatch(a -> "ROLE_PHOTOGRAPHER".equals(a.getAuthority()))) {
+            return false;
+        }
+        String ownerUsername = item.getPhotographer().getAccount().getUsername();
+        return ownerUsername != null && ownerUsername.equals(authentication.getName());
+    }
+
+    private ItemRegisterRequest toItemRegisterRequest(Item item) {
+        ItemRegisterRequest request = new ItemRegisterRequest();
+        request.setTagName(item.getTag().getName());
+        request.setItemType(item.getItemType());
+        request.setName(item.getName());
+        request.setDescription(item.getDescription());
+        request.setIncludes(item.getIncludes());
+        request.setExcludes(item.getExcludes());
+        request.setAddress(item.getAddress());
+        request.setLat(item.getLat());
+        request.setLng(item.getLng());
+        request.setMinBookingLeadTime(item.getMinBookingLeadTime());
+        request.setCancellationPolicy(item.getCancellationPolicy());
+
+        List<PlanRegisterRequest> plans = new ArrayList<>();
+        item.getPlanList().stream()
+            .sorted(Comparator.comparing(Plan::getId))
+            .forEach(plan -> {
+                PlanRegisterRequest planRequest = new PlanRegisterRequest();
+                planRequest.setPlanName(plan.getName());
+                planRequest.setPrice(plan.getPrice());
+                planRequest.setShootingDuration(plan.getShootingDuration());
+                planRequest.setOriginalPhotoCount(plan.getOriginalPhotoCount());
+                planRequest.setEditedPhotoCount(plan.getEditedPhotoCount());
+                planRequest.setDeliveryDays(plan.getDeliveryDays());
+                plans.add(planRequest);
+            });
+        request.setPlans(plans);
+        return request;
     }
 }

--- a/src/main/java/com/pickkasso/pickkasso/item/entity/Item.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/entity/Item.java
@@ -172,4 +172,28 @@ public class Item extends Region {
         itemNoticeList.clear();
         itemNoticeList.addAll(newItemNoticeList);
     }
+
+    public void updateBasicInfo(
+        Tag tag,
+        String name,
+        String description,
+        String includes,
+        String excludes,
+        ItemType itemType,
+        Integer minBookingLeadTime,
+        String cancellationPolicy,
+        String address,
+        Double lat,
+        Double lng
+    ) {
+        this.tag = tag;
+        this.name = name;
+        this.description = description != null ? description : "";
+        this.includes = includes;
+        this.excludes = excludes;
+        this.itemType = itemType;
+        this.minBookingLeadTime = minBookingLeadTime != null ? minBookingLeadTime : 1;
+        this.cancellationPolicy = cancellationPolicy;
+        initRegion(address, this.getDetailAddress(), lat, lng);
+    }
 }

--- a/src/main/java/com/pickkasso/pickkasso/item/service/ItemService.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/service/ItemService.java
@@ -90,6 +90,52 @@ public class ItemService {
         return itemRepository.save(item).getId();
     }
 
+    public Long updateItem(Long photographerId, Long itemId, ItemRegisterRequest request) {
+        Item item = itemRepository.findByIdWithDetails(itemId)
+            .orElseThrow(() -> new IllegalArgumentException("서비스를 찾을 수 없습니다."));
+        if (!item.getPhotographer().getId().equals(photographerId)) {
+            throw new IllegalArgumentException("본인 서비스만 수정할 수 있습니다.");
+        }
+
+        Tag tag = tagRepository.findTagByName(request.getTagName())
+            .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다: " + request.getTagName()));
+
+        item.updateBasicInfo(
+            tag,
+            request.getName(),
+            request.getDescription(),
+            request.getIncludes(),
+            request.getExcludes(),
+            request.getItemType(),
+            request.getMinBookingLeadTime(),
+            request.getCancellationPolicy(),
+            request.getAddress(),
+            request.getLat(),
+            request.getLng()
+        );
+
+        List<Plan> existingPlans = new ArrayList<>(item.getPlanList());
+        for (Plan plan : existingPlans) {
+            plan.deletePlan();
+        }
+
+        if (request.getPlans() != null) {
+            for (PlanRegisterRequest planReq : request.getPlans()) {
+                Plan.createPlan(
+                    item,
+                    planReq.getPlanName(),
+                    planReq.getPrice() != null ? planReq.getPrice() : 0,
+                    planReq.getShootingDuration() != null ? planReq.getShootingDuration() : 1,
+                    planReq.getOriginalPhotoCount() != null ? planReq.getOriginalPhotoCount() : 0,
+                    planReq.getEditedPhotoCount() != null ? planReq.getEditedPhotoCount() : 0,
+                    planReq.getDeliveryDays() != null ? planReq.getDeliveryDays() : 3
+                );
+            }
+        }
+        item.updateDefaultPrice();
+        return itemRepository.save(item).getId();
+    }
+
     private List<ItemBoxDto> getItemBoxDtoList(List<Item> itemList) {
         List<ItemBoxDto> resList = new ArrayList<>();
         for (Item item : itemList) {

--- a/src/main/resources/templates/photographer/service-detail.html
+++ b/src/main/resources/templates/photographer/service-detail.html
@@ -294,7 +294,8 @@
             </ul>
 
             <!-- CTA buttons -->
-            <a th:href="@{/items/{id}/reserve(id=${item.id}, planId=${plan.id})}"
+            <a sec:authorize="!hasRole('PHOTOGRAPHER')"
+               th:href="@{/items/{id}/reserve(id=${item.id}, planId=${plan.id})}"
                class="block w-full bg-white border border-[#1D3CFF] text-[#1D3CFF] hover:bg-[#1D3CFF] hover:text-white active:bg-[#1530E0] font-semibold py-3 rounded-lg transition-colors text-sm text-center">
               예약하기
             </a>
@@ -334,12 +335,11 @@
           </ul>
         </div>
 
-        <!-- 비슷한 작가 placeholder -->
-        <div class="bg-white border border-[#CCC] rounded-2xl p-5">
-          <h3 class="text-sm font-semibold text-[#1A1A1A] mb-4">비슷한 작가</h3>
-          <div class="rounded-xl border border-dashed border-[#CCC] bg-[#F9FAFC] px-4 py-5 text-center">
-            <p class="text-xs text-[#888]">추천 기능은 준비 중입니다.</p>
-          </div>
+        <div th:if="${canEditService}" class="bg-white border border-[#CCC] rounded-2xl p-5">
+          <a th:href="@{/photographer/{photographerId}/item/{itemId}/edit(photographerId=${item.photographer.id}, itemId=${item.id})}"
+             class="inline-flex w-full items-center justify-center gap-2 bg-white border border-[#1D3CFF] text-[#1D3CFF] hover:bg-[#1D3CFF] hover:text-white active:bg-[#1530E0] font-semibold px-5 py-2.5 rounded-lg transition-colors text-sm">
+            수정하기
+          </a>
         </div>
 
       </aside>

--- a/src/main/resources/templates/photographer/service-edit.html
+++ b/src/main/resources/templates/photographer/service-edit.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko"
+      th:replace="~{photographer/service-register}">
+</html>

--- a/src/main/resources/templates/photographer/service-register.html
+++ b/src/main/resources/templates/photographer/service-register.html
@@ -144,7 +144,7 @@
       <span th:text="${errorMessage}"></span>
     </div>
 
-    <form th:action="@{/photographer/{id}/service/new(id=${photographerId})}"
+    <form th:action="${formAction}"
           method="post" id="service-form"
           class="flex flex-col gap-5">
 
@@ -170,7 +170,9 @@
             <div class="grid grid-cols-4 gap-2.5" id="category-grid">
               <th:block th:each="tag : ${tagList}">
                 <label class="category-option relative flex flex-col items-center justify-center gap-2 py-4 px-2.5 bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-xl cursor-pointer text-[13px] font-medium text-[#444] text-center leading-snug transition-all hover:border-[#1D3CFF] hover:bg-[#EEF1FF]">
-                  <input type="radio" name="tagName" th:value="${tag.name}" class="absolute opacity-0 w-0 h-0">
+                  <input type="radio" name="tagName" th:value="${tag.name}"
+                         th:checked="${itemRegisterRequest.tagName == tag.name}"
+                         class="absolute opacity-0 w-0 h-0">
                   <span class="cat-emoji text-2xl" th:text="${categoryEmojis[tag.name] ?: '📷'}">📷</span>
                   <span th:text="${tag.name}">카테고리</span>
                 </label>
@@ -219,7 +221,8 @@
               촬영 방식            </label>
             <div class="flex gap-3">
               <label class="shoot-type-option flex-1 relative flex items-center gap-3.5 px-5 py-4 bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-xl cursor-pointer transition-all hover:border-[#1D3CFF]">
-                <input type="radio" name="itemType" value="OUT" class="absolute opacity-0 w-0 h-0" checked>
+                <input type="radio" name="itemType" value="OUT" class="absolute opacity-0 w-0 h-0"
+                       th:checked="${itemRegisterRequest.itemType == null or itemRegisterRequest.itemType.name() == 'OUT'}">
                 <div class="w-10 h-10 rounded-[10px] bg-[#D3DEF2] flex items-center justify-center text-xl flex-shrink-0">📍</div>
                 <div>
                   <div class="text-sm font-bold text-[#1A1A1A]">방문 촬영</div>
@@ -227,7 +230,8 @@
                 </div>
               </label>
               <label class="shoot-type-option flex-1 relative flex items-center gap-3.5 px-5 py-4 bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-xl cursor-pointer transition-all hover:border-[#1D3CFF]">
-                <input type="radio" name="itemType" value="IN" class="absolute opacity-0 w-0 h-0">
+                <input type="radio" name="itemType" value="IN" class="absolute opacity-0 w-0 h-0"
+                       th:checked="${itemRegisterRequest.itemType != null and itemRegisterRequest.itemType.name() == 'IN'}">
                 <div class="w-10 h-10 rounded-[10px] bg-[#D3DEF2] flex items-center justify-center text-xl flex-shrink-0">🏢</div>
                 <div>
                   <div class="text-sm font-bold text-[#1A1A1A]">스튜디오 촬영</div>
@@ -242,6 +246,7 @@
             <label for="service-name" class="text-[13px] font-bold text-[#1A1A1A] flex items-center gap-1">
               서비스명            </label>
             <input id="service-name" type="text" name="name" maxlength="60"
+                   th:value="${itemRegisterRequest.name}"
                    placeholder="예: 감성 데이트 스냅 2시간 패키지"
                    class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-[10px] px-3.5 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] focus:ring-[3px] focus:ring-[#1D3CFF]/[0.08] transition-all">
           </div>
@@ -282,32 +287,38 @@
               <div class="plan-row grid grid-cols-[2fr_1fr_1fr_1fr_1fr_1.5fr_36px] items-center px-4 py-3.5 border-b border-[#CCC] last:border-b-0 gap-2">
                 <div class="flex items-center gap-2">
                   <span class="text-base leading-none flex-shrink-0">📸</span>
-                  <input type="text" name="plans[0].planName" value="기본 패키지"
+                  <input type="text" name="plans[0].planName"
+                         th:value="${#lists.isEmpty(itemRegisterRequest.plans) ? '기본 패키지' : itemRegisterRequest.plans[0].planName}"
                          placeholder="패키지명"
                          class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-2.5 py-1.5 text-[13px] text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] transition-colors">
                 </div>
                 <div class="flex items-center justify-center gap-1">
-                  <input type="number" name="plans[0].shootingDuration" value="2" min="1" max="12"
+                  <input type="number" name="plans[0].shootingDuration"
+                         th:value="${#lists.isEmpty(itemRegisterRequest.plans) ? 2 : itemRegisterRequest.plans[0].shootingDuration}" min="1" max="12"
                          class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
                   <span class="text-xs text-[#888] flex-shrink-0">시간</span>
                 </div>
                 <div class="flex items-center justify-center gap-1">
-                  <input type="number" name="plans[0].originalPhotoCount" value="100" min="0"
+                  <input type="number" name="plans[0].originalPhotoCount"
+                         th:value="${#lists.isEmpty(itemRegisterRequest.plans) ? 100 : itemRegisterRequest.plans[0].originalPhotoCount}" min="0"
                          class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
                   <span class="text-xs text-[#888] flex-shrink-0">장</span>
                 </div>
                 <div class="flex items-center justify-center gap-1">
-                  <input type="number" name="plans[0].editedPhotoCount" value="20" min="0"
+                  <input type="number" name="plans[0].editedPhotoCount"
+                         th:value="${#lists.isEmpty(itemRegisterRequest.plans) ? 20 : itemRegisterRequest.plans[0].editedPhotoCount}" min="0"
                          class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
                   <span class="text-xs text-[#888] flex-shrink-0">장</span>
                 </div>
                 <div class="flex items-center justify-center gap-1">
-                  <input type="number" name="plans[0].deliveryDays" value="3" min="1"
+                  <input type="number" name="plans[0].deliveryDays"
+                         th:value="${#lists.isEmpty(itemRegisterRequest.plans) ? 3 : itemRegisterRequest.plans[0].deliveryDays}" min="1"
                          class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
                   <span class="text-xs text-[#888] flex-shrink-0">일</span>
                 </div>
                 <div class="relative flex items-center">
                   <input type="number" name="plans[0].price" placeholder="0" min="0"
+                         th:value="${#lists.isEmpty(itemRegisterRequest.plans) ? null : itemRegisterRequest.plans[0].price}"
                          class="plan-price w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-2.5 pr-7 py-1.5 text-[13px] text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] transition-colors">
                   <span class="absolute right-2.5 text-xs text-[#888] pointer-events-none">원</span>
                 </div>
@@ -339,9 +350,10 @@
             <label class="text-[13px] font-bold text-[#1A1A1A]">기준 지점 (출발지)</label>
             <p class="text-xs text-[#888]">방문 촬영 시 이동 거리 계산의 기준이 됩니다</p>
             <input type="text" name="address" placeholder="예: 서울 마포구 합정동"
+                   th:value="${itemRegisterRequest.address}"
                    class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-[10px] px-3.5 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] focus:ring-[3px] focus:ring-[#1D3CFF]/[0.08] transition-all">
-            <input type="hidden" name="lat" value="0.0">
-            <input type="hidden" name="lng" value="0.0">
+            <input type="hidden" name="lat" th:value="${itemRegisterRequest.lat != null ? itemRegisterRequest.lat : 0.0}">
+            <input type="hidden" name="lng" th:value="${itemRegisterRequest.lng != null ? itemRegisterRequest.lng : 0.0}">
           </div>
 
           <!-- 추가 옵션 -->
@@ -401,7 +413,7 @@
             <textarea name="description" rows="6" maxlength="1000"
                       placeholder="이 서비스가 어떤 고객에게 적합한지, 촬영 과정은 어떻게 진행되는지 자세히 설명해 주세요."
                       class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-[10px] px-3.5 py-3 text-sm text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] focus:ring-[3px] focus:ring-[#1D3CFF]/[0.08] resize-y leading-7 transition-all"
-                      id="desc-textarea"></textarea>
+                      id="desc-textarea" th:text="${itemRegisterRequest.description}"></textarea>
             <div class="text-xs text-[#AAA] text-right"><span id="desc-count">0</span> / 1000자</div>
           </div>
 
@@ -467,6 +479,7 @@
             <p class="text-xs text-[#888]">촬영일 기준 최소 며칠 전에 예약해야 하는지 설정합니다</p>
             <div class="relative mt-1 max-w-[200px]">
               <input id="lead-time" type="number" name="minBookingLeadTime" placeholder="3" min="1" max="90"
+                     th:value="${itemRegisterRequest.minBookingLeadTime}"
                      class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-[10px] px-3.5 py-2.5 pr-14 text-sm text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] focus:ring-[3px] focus:ring-[#1D3CFF]/[0.08] transition-all">
               <span class="absolute right-3.5 top-1/2 -translate-y-1/2 text-[13px] text-[#888] font-medium pointer-events-none">일 전</span>
             </div>
@@ -485,7 +498,8 @@
             </div>
             <textarea name="cancellationPolicy" rows="3"
                       placeholder="추가 취소/환불 안내 사항이 있으면 작성해 주세요."
-                      class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-[10px] px-3.5 py-3 text-sm text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] focus:ring-[3px] focus:ring-[#1D3CFF]/[0.08] resize-y leading-7 transition-all mt-1"></textarea>
+                      class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-[10px] px-3.5 py-3 text-sm text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] focus:ring-[3px] focus:ring-[#1D3CFF]/[0.08] resize-y leading-7 transition-all mt-1"
+                      th:text="${itemRegisterRequest.cancellationPolicy}"></textarea>
           </div>
 
           <!-- 고객 안내 사항 -->
@@ -555,6 +569,10 @@
       updatePreview();
     });
   });
+  const initialCategory = document.querySelector('.category-option input:checked');
+  if (initialCategory) {
+    initialCategory.dispatchEvent(new Event('change'));
+  }
 
   /* ─── 촬영 방식 선택 ─── */
   document.querySelectorAll('.shoot-type-option').forEach(label => {
@@ -575,8 +593,12 @@
       updatePreview();
     });
   });
-  // 초기 방문촬영 선택 상태 표시
-  document.querySelector('.shoot-type-option input[value="OUT"]').dispatchEvent(new Event('change'));
+  // 초기 선택 상태 표시
+  const initialShootType = document.querySelector('.shoot-type-option input:checked')
+    || document.querySelector('.shoot-type-option input[value="OUT"]');
+  if (initialShootType) {
+    initialShootType.dispatchEvent(new Event('change'));
+  }
 
   /* ─── 패키지 추가/삭제 ─── */
   let planIndex = 1;


### PR DESCRIPTION
## 작업내용
- 서비스 상세 페이지에서 권한별 UI 처리
  - 작가(`PHOTOGRAPHER`)는 `예약하기` 버튼 숨김
  - 본인 서비스일 때만 `수정하기` 버튼 노출
- 서비스 수정 기능 추가
  - `GET /photographer/{photographerId}/item/{itemId}/edit`
  - `POST /photographer/{photographerId}/item/{itemId}/edit`
- 수정 화면 view 추가
  - `photographer/service-edit` (기존 `service-register` 재사용)
- 상세 우측 UI 정리
  - `비슷한 작가` 섹션 제거
  - 해당 위치에 `수정하기` 버튼 배치 및 `작가 프로필 보기`와 동일 스타일 적용

## 변경사항
- `ServiceRegisterController`
  - 클래스/메서드 매핑 재구성
  - 수정 GET/POST 핸들러 추가
  - 성공/실패 분기(성공 redirect, 실패 view + errorMessage) 반영
- `service-detail.html`
  - 작가 예약 버튼 숨김
  - 수정 버튼 위치/스타일 변경
  - 비슷한 작가 영역 제거
- `service-register.html`
  - 수정 시 기존 데이터 프리필(prefill) 및 동적 formAction 대응
- `service-edit.html`
  - 명세 view 이름 대응용 템플릿 추가

## 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 관련 페이지 렌더링 확인

## 참고
- 관련 이슈 번호나 참고 링크