### PR TITLE
feat: item 기능 추가

### DIFF
--- a/src/main/java/com/pickkasso/pickkasso/global/city/City.java
+++ b/src/main/java/com/pickkasso/pickkasso/global/city/City.java
@@ -48,7 +48,7 @@ public enum City {
     public static City fromString(String value) {
         if (value == null) throw new IllegalArgumentException("City value must not be null");
         return Arrays.stream(values())
-            .filter(c -> c.aliases.stream().anyMatch(a -> a.startsWith(value)))
+            .filter(c -> c.aliases.stream().anyMatch(value::startsWith))
             .findFirst()
             .orElseThrow(() -> new IllegalArgumentException("Unknown city: " + value));
     }

--- a/src/main/java/com/pickkasso/pickkasso/global/config/ReservationDevSeeder.java
+++ b/src/main/java/com/pickkasso/pickkasso/global/config/ReservationDevSeeder.java
@@ -5,6 +5,7 @@ import com.pickkasso.pickkasso.global.tag.TagRepository;
 import com.pickkasso.pickkasso.item.entity.Item;
 import com.pickkasso.pickkasso.item.entity.ItemType;
 import com.pickkasso.pickkasso.item.entity.Plan;
+import com.pickkasso.pickkasso.item.entity.PlanType;
 import com.pickkasso.pickkasso.item.repository.ItemRepository;
 import com.pickkasso.pickkasso.user.entity.*;
 import com.pickkasso.pickkasso.user.repository.*;
@@ -103,32 +104,32 @@ public class ReservationDevSeeder implements ApplicationRunner {
                 "전문 프로필 사진 촬영", "보정 3컷 포함", "의상 및 메이크업 별도",
                 ItemType.IN, 24, "촬영 3일 전부터 환불 불가",
                 "서울특별시 강남구 테헤란로 1", 37.5000, 127.0370,
-                "1인 프로필", 80000, 60, 120, 3, 3);
+                PlanType.STANDARD, "1인 프로필", 80000, 60, 120, 3, 3);
         ensureItem(itemsByName, photographer, "데이트", "데이트 스냅",
                 "자연스러운 커플 스냅 촬영", "원본 전체 제공", "입장료 별도",
                 ItemType.OUT, 48, "촬영 5일 전부터 일정 변경만 가능",
                 "서울특별시 마포구 양화로 188", 37.5570, 126.9245,
-                "커플 2시간", 150000, 120, 250, 10, 5);
+                PlanType.STANDARD, "커플 2시간", 150000, 120, 250, 10, 5);
         ensureItem(itemsByName, photographer, "증명", "증명사진",
                 "빠르게 완성하는 증명사진 촬영", "기본 보정 포함", "인화 배송 별도",
                 ItemType.IN, 12, "촬영 전날까지 취소 가능",
                 "서울특별시 강남구 봉은사로 112", 37.5045, 127.0280,
-                "기본 증명", 50000, 30, 20, 2, 2);
+                PlanType.STANDARD, "기본 증명", 50000, 30, 20, 2, 2);
         ensureItem(itemsByName, photographer, "웨딩", "웨딩 스냅",
                 "본식 전후 웨딩 스냅 촬영", "보정본 20컷 포함", "드레스 및 부케 별도",
                 ItemType.OUT, 72, "촬영 7일 전부터 환불 불가",
                 "서울특별시 용산구 서빙고로 137", 37.5204, 126.9946,
-                "웨딩 하프데이", 200000, 180, 400, 20, 7);
+                PlanType.STANDARD, "웨딩 하프데이", 200000, 180, 400, 20, 7);
         ensureItem(itemsByName, photographer, "졸업", "졸업사진",
                 "졸업 시즌 야외/실내 촬영", "보정본 8컷 포함", "학사복 대여 별도",
                 ItemType.OUT, 24, "우천 시 일정 조율",
                 "서울특별시 종로구 세종대로 175", 37.5720, 126.9769,
-                "졸업 2시간", 180000, 120, 220, 8, 4);
+                PlanType.STANDARD, "졸업 2시간", 180000, 120, 220, 8, 4);
         ensureItem(itemsByName, photographer, "가족", "가족사진",
                 "자연스러운 가족 야외 촬영", "보정본 6컷 포함", "소품은 개별 준비",
                 ItemType.OUT, 24, "촬영 2일 전까지 변경 가능",
                 "경기도 성남시 분당구 문정로 145", 37.3786, 127.1492,
-                "가족 1시간", 130000, 60, 150, 6, 4);
+                PlanType.STANDARD, "가족 1시간", 130000, 60, 150, 6, 4);
 
         return itemsByName;
     }
@@ -146,6 +147,7 @@ public class ReservationDevSeeder implements ApplicationRunner {
                             String address,
                             double lat,
                             double lng,
+                            PlanType planType,
                             String planName,
                             int price,
                             int shootingDuration,
@@ -162,7 +164,7 @@ public class ReservationDevSeeder implements ApplicationRunner {
                 includes, excludes, itemType, minBookingLeadTime,
                 cancellationPolicy, address, lat, lng
         );
-        Plan.createPlan(item, planName, price, shootingDuration, originalPhotoCount, editedPhotoCount, deliveryDays);
+        Plan.createPlan(item, planType, true, planName, price, shootingDuration, originalPhotoCount, editedPhotoCount, deliveryDays);
         itemRepository.save(item);
         itemsByName.put(itemName, item);
         log.info("[seed] created dev item: {}", itemName);
@@ -170,7 +172,7 @@ public class ReservationDevSeeder implements ApplicationRunner {
 
     private Tag ensureTag(String name) {
         return tagRepository.findTagByName(name)
-                .orElseGet(() -> tagRepository.save(Tag.createTag(name)));
+                .orElseGet(() -> tagRepository.save(Tag.createTag(name, "")));
     }
 
     private void save(Reservation r, ReservationStatus targetStatus) {

--- a/src/main/java/com/pickkasso/pickkasso/global/service/DefaultImgService.java
+++ b/src/main/java/com/pickkasso/pickkasso/global/service/DefaultImgService.java
@@ -68,8 +68,10 @@ public class DefaultImgService {
         }
 
         // 2. 신규 업로드
-        for (int i = 0; i < newFiles.size(); i++) {
-            result.add(uploadImage(newFiles.get(i), newFileOrders.get(i), dirName));
+        if (newFiles != null && !newFiles.isEmpty()) {
+            for (int i = 0; i < newFiles.size(); i++) {
+                result.add(uploadImage(newFiles.get(i), newFileOrders.get(i), dirName));
+            }
         }
 
         // 3. 삭제

--- a/src/main/java/com/pickkasso/pickkasso/global/tag/Tag.java
+++ b/src/main/java/com/pickkasso/pickkasso/global/tag/Tag.java
@@ -18,12 +18,16 @@ public class Tag {
     @Column(name = "name")
     private String name;
 
-    private Tag(String name) {
+    @Column(name = "emoji")
+    private String emoji;
+
+    private Tag(String name, String emoji) {
         this.name = name;
+        this.emoji = emoji;
     }
 
     //== 생성 method ==//
-    public static Tag createTag(String name) {
-        return new Tag(name);
+    public static Tag createTag(String name, String emoji) {
+        return new Tag(name, emoji);
     }
 }

--- a/src/main/java/com/pickkasso/pickkasso/global/tag/TagReference.java
+++ b/src/main/java/com/pickkasso/pickkasso/global/tag/TagReference.java
@@ -9,17 +9,20 @@ import lombok.Getter;
 public class TagReference {
     private Long id;
     private String name;
+    private String emoji;
 
     @QueryProjection
-    public TagReference(Long id, String name) {
+    public TagReference(Long id, String name, String emoji) {
         this.id = id;
         this.name = name;
+        this.emoji = emoji;
     }
 
     public static TagReference from(Tag tag) {
         return TagReference.builder()
             .id(tag.getId())
             .name(tag.getName())
+            .emoji(tag.getEmoji())
             .build();
     }
 }

--- a/src/main/java/com/pickkasso/pickkasso/global/tag/TagRepository.java
+++ b/src/main/java/com/pickkasso/pickkasso/global/tag/TagRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
-    @Query("select new com.pickkasso.pickkasso.global.tag.TagReference(t.id, t.name) from Tag t")
+    @Query("select new com.pickkasso.pickkasso.global.tag.TagReference(t.id, t.name, t.emoji) from Tag t")
     List<TagReference> findAllTagReference();
 
     @Query("select t from Tag t where t.name = :name")

--- a/src/main/java/com/pickkasso/pickkasso/item/controller/ItemController.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/controller/ItemController.java
@@ -87,6 +87,7 @@ public class ItemController {
         model.addAttribute("item", item);
         model.addAttribute("enabledPlans", planService.getEnabledPlans(id));
         model.addAttribute("profile", photographerProfileService.getProfileForm(photographerId));
+        model.addAttribute("itemImgList", itemService.getItemImage(photographerId, id));
         return "photographer/service-detail";
     }
 }

--- a/src/main/java/com/pickkasso/pickkasso/item/controller/ItemController.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/controller/ItemController.java
@@ -7,6 +7,7 @@ import com.pickkasso.pickkasso.item.dto.ItemSearchFormDto;
 import com.pickkasso.pickkasso.item.entity.ItemType;
 import com.pickkasso.pickkasso.item.entity.Item;
 import com.pickkasso.pickkasso.item.service.ItemService;
+import com.pickkasso.pickkasso.item.service.PlanService;
 import com.pickkasso.pickkasso.user.service.PhotographerProfileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -24,6 +25,7 @@ public class ItemController {
     private final TagService tagService;
     private final ItemService itemService;
     private final PhotographerProfileService photographerProfileService;
+    private final PlanService planService;
     private static final int PAGE_VIEW_COUNT = 20;
 
     private ItemSearchCondition toCondition(ItemSearchFormDto dto) {
@@ -83,6 +85,7 @@ public class ItemController {
         Item item = itemService.getItemById(id);
         Long photographerId = item.getPhotographer().getId();
         model.addAttribute("item", item);
+        model.addAttribute("enabledPlans", planService.getEnabledPlans(id));
         model.addAttribute("profile", photographerProfileService.getProfileForm(photographerId));
         return "photographer/service-detail";
     }

--- a/src/main/java/com/pickkasso/pickkasso/item/controller/ServiceRegisterController.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/controller/ServiceRegisterController.java
@@ -36,6 +36,7 @@ public class ServiceRegisterController {
         model.addAttribute("item", item);
         model.addAttribute("profile", photographerProfileService.getProfileForm(photographerId));
         model.addAttribute("enabledPlans", planService.getEnabledPlans(itemId));
+        model.addAttribute("itemImgList", itemService.getItemImage(photographerId, itemId));
         return "photographer/service-detail";
     }
 

--- a/src/main/java/com/pickkasso/pickkasso/item/controller/ServiceRegisterController.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/controller/ServiceRegisterController.java
@@ -3,7 +3,9 @@ package com.pickkasso.pickkasso.item.controller;
 import com.pickkasso.pickkasso.global.tag.TagService;
 import com.pickkasso.pickkasso.item.dto.ItemRegisterRequest;
 import com.pickkasso.pickkasso.item.entity.Item;
+import com.pickkasso.pickkasso.item.entity.PlanType;
 import com.pickkasso.pickkasso.item.service.ItemService;
+import com.pickkasso.pickkasso.item.service.PlanService;
 import com.pickkasso.pickkasso.user.service.PhotographerProfileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -13,7 +15,6 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import java.util.List;
-import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
@@ -23,29 +24,7 @@ public class ServiceRegisterController {
     private final ItemService itemService;
     private final TagService tagService;
     private final PhotographerProfileService photographerProfileService;
-
-    // private static final Map<String, String> CATEGORY_EMOJIS = Map.ofEntries(
-    //     Map.entry("데이트스냅", "🌸"),
-    //     Map.entry("데이트 스냅", "🌸"),
-    //     Map.entry("프로필", "🤳"),
-    //     Map.entry("졸업", "🎓"),
-    //     Map.entry("졸업사진", "🎓"),
-    //     Map.entry("웨딩", "💒"),
-    //     Map.entry("웨딩 스냅", "💒"),
-    //     Map.entry("가족/아이", "👨‍👩‍👧"),
-    //     Map.entry("가족사진", "👨‍👩‍👧"),
-    //     Map.entry("증명사진", "🪪"),
-    //     Map.entry("반려동물", "🐾"),
-    //     Map.entry("제품/커머셜", "🛍️"),
-    //     Map.entry("제품 촬영", "🛍️"),
-    //     Map.entry("음식", "🍽️"),
-    //     Map.entry("건축", "🏛️"),
-    //     Map.entry("야외", "🌿"),
-    //     Map.entry("야외 촬영", "🌿"),
-    //     Map.entry("스튜디오", "🎞️"),
-    //     Map.entry("드론", "🚁"),
-    //     Map.entry("공연", "🎭")
-    // );
+    private final PlanService planService;
 
     @GetMapping("/{itemId}")
     public String serviceDetail(
@@ -56,6 +35,7 @@ public class ServiceRegisterController {
         Item item = itemService.getItemById(itemId);
         model.addAttribute("item", item);
         model.addAttribute("profile", photographerProfileService.getProfileForm(photographerId));
+        model.addAttribute("enabledPlans", planService.getEnabledPlans(itemId));
         return "photographer/service-detail";
     }
 
@@ -64,6 +44,7 @@ public class ServiceRegisterController {
         model.addAttribute("photographerId", photographerId);
         model.addAttribute("tagList", tagService.findAllTagReference());
         model.addAttribute("itemRegisterRequest", new ItemRegisterRequest());
+        model.addAttribute("planTypes", PlanType.values());
         model.addAttribute("formAction", "/photographer/" + photographerId + "/service/new");
         return "photographer/service-register";
     }
@@ -81,7 +62,7 @@ public class ServiceRegisterController {
         try {
             Long itemId = itemService.registerItem(photographerId, itemRegisterRequest, newFiles, newFileOrders);
             redirectAttributes.addFlashAttribute("successMessage", "서비스가 등록되었습니다.");
-            return "redirect:/photographer/" + photographerId + "/profile";
+            return "redirect:/photographer/" + photographerId + "/service/" + itemId;
         } catch (Exception e) {
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
             return "redirect:/photographer/" + photographerId + "/service/new";
@@ -95,7 +76,8 @@ public class ServiceRegisterController {
         model.addAttribute("tagList", tagService.findAllTagReference());
         model.addAttribute("itemRegisterRequest", itemService.getItemRegisterRequest(photographerId, itemId));
         model.addAttribute("itemImgList", itemService.getItemImage(photographerId, itemId));
-        model.addAttribute("formAction", "/photographer/" + photographerId + "/service/edit");
+        model.addAttribute("planTypes", PlanType.values());
+        model.addAttribute("formAction", "/photographer/" + photographerId + "/service/" + itemId + "/edit");
         return "photographer/service-register";
     }
 
@@ -114,10 +96,10 @@ public class ServiceRegisterController {
         try {
             itemService.updateItem(photographerId, itemId, itemRegisterRequest, keptImgUrls, keptImgOrders, newFiles, newFileOrders);
             redirectAttributes.addFlashAttribute("successMessage", "서비스가 수정되었습니다.");
-            return "redirect:/photographer/" + photographerId + "/" + itemId;
+            return "redirect:/photographer/" + photographerId + "/service/" + itemId;
         } catch (Exception e) {
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
-            return "redirect:/photographer/" + photographerId + "/" + itemId + "/edit";
+            return "redirect:/photographer/" + photographerId + "/service/" + itemId + "/edit";
         }
     }
 }

--- a/src/main/java/com/pickkasso/pickkasso/item/controller/ServiceRegisterController.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/controller/ServiceRegisterController.java
@@ -26,28 +26,28 @@ public class ServiceRegisterController {
     private final TagService tagService;
     private final PhotographerProfileService photographerProfileService;
 
-    private static final Map<String, String> CATEGORY_EMOJIS = Map.ofEntries(
-        Map.entry("데이트스냅", "🌸"),
-        Map.entry("데이트 스냅", "🌸"),
-        Map.entry("프로필", "🤳"),
-        Map.entry("졸업", "🎓"),
-        Map.entry("졸업사진", "🎓"),
-        Map.entry("웨딩", "💒"),
-        Map.entry("웨딩 스냅", "💒"),
-        Map.entry("가족/아이", "👨‍👩‍👧"),
-        Map.entry("가족사진", "👨‍👩‍👧"),
-        Map.entry("증명사진", "🪪"),
-        Map.entry("반려동물", "🐾"),
-        Map.entry("제품/커머셜", "🛍️"),
-        Map.entry("제품 촬영", "🛍️"),
-        Map.entry("음식", "🍽️"),
-        Map.entry("건축", "🏛️"),
-        Map.entry("야외", "🌿"),
-        Map.entry("야외 촬영", "🌿"),
-        Map.entry("스튜디오", "🎞️"),
-        Map.entry("드론", "🚁"),
-        Map.entry("공연", "🎭")
-    );
+    // private static final Map<String, String> CATEGORY_EMOJIS = Map.ofEntries(
+    //     Map.entry("데이트스냅", "🌸"),
+    //     Map.entry("데이트 스냅", "🌸"),
+    //     Map.entry("프로필", "🤳"),
+    //     Map.entry("졸업", "🎓"),
+    //     Map.entry("졸업사진", "🎓"),
+    //     Map.entry("웨딩", "💒"),
+    //     Map.entry("웨딩 스냅", "💒"),
+    //     Map.entry("가족/아이", "👨‍👩‍👧"),
+    //     Map.entry("가족사진", "👨‍👩‍👧"),
+    //     Map.entry("증명사진", "🪪"),
+    //     Map.entry("반려동물", "🐾"),
+    //     Map.entry("제품/커머셜", "🛍️"),
+    //     Map.entry("제품 촬영", "🛍️"),
+    //     Map.entry("음식", "🍽️"),
+    //     Map.entry("건축", "🏛️"),
+    //     Map.entry("야외", "🌿"),
+    //     Map.entry("야외 촬영", "🌿"),
+    //     Map.entry("스튜디오", "🎞️"),
+    //     Map.entry("드론", "🚁"),
+    //     Map.entry("공연", "🎭")
+    // );
 
     @GetMapping("/{itemId}")
     public String serviceDetail(
@@ -65,7 +65,6 @@ public class ServiceRegisterController {
     public String serviceRegisterForm(@PathVariable Long photographerId, Model model) {
         model.addAttribute("photographerId", photographerId);
         model.addAttribute("tagList", tagService.findAllTagReference());
-        model.addAttribute("categoryEmojis", CATEGORY_EMOJIS);
         model.addAttribute("itemRegisterRequest", new ItemRegisterRequest());
         return "photographer/service-register";
     }

--- a/src/main/java/com/pickkasso/pickkasso/item/controller/ServiceRegisterController.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/controller/ServiceRegisterController.java
@@ -86,7 +86,18 @@ public class ServiceRegisterController {
 
 
     @GetMapping("/{itemId}/edit")
-    public String serviceEditForm(@PathVariable Long photographerId, @PathVariable Long itemId, Model model) {
+    public String serviceEditForm(
+        @PathVariable Long photographerId,
+        @PathVariable Long itemId,
+        Authentication authentication,
+        Model model) {
+        ensurePhotographerOwner(authentication, photographerId);
+
+        Item item = itemService.getItemById(itemId);
+        if (!item.getPhotographer().getId().equals(photographerId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인 서비스만 수정할 수 있습니다.");
+        }
+
         model.addAttribute("photographerId", photographerId);
         model.addAttribute("tagList", tagService.findAllTagReference());
         model.addAttribute("itemRegisterRequest", itemService.getItemRegisterRequest(photographerId, itemId));
@@ -96,17 +107,19 @@ public class ServiceRegisterController {
         return "photographer/service-register";
     }
 
-
+    // 예외처리 부분 반영하지 않음
     @PostMapping("/{itemId}/edit")
     public String updateService(
         @PathVariable Long photographerId,
         @PathVariable Long itemId,
+        Authentication authentication,
         @ModelAttribute ItemRegisterRequest itemRegisterRequest,
         @RequestParam(required = false) List<String> keptImgUrls,
         @RequestParam(required = false) List<Integer> keptImgOrders,
         @RequestParam(required = false) List<MultipartFile> newFiles,
         @RequestParam(required = false) List<Integer> newFileOrders,
         RedirectAttributes redirectAttributes) {
+        ensurePhotographerOwner(authentication, photographerId);
 
         try {
             itemService.updateItem(photographerId, itemId, itemRegisterRequest, keptImgUrls, keptImgOrders, newFiles, newFileOrders);
@@ -115,6 +128,16 @@ public class ServiceRegisterController {
         } catch (Exception e) {
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
             return "redirect:/photographer/" + photographerId + "/service/" + itemId + "/edit";
+        }
+    }
+
+    private void ensurePhotographerOwner(Authentication authentication, Long photographerId) {
+        if (authentication == null || authentication.getName() == null) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+        }
+        Account account = accountRepository.findByUsername(authentication.getName());
+        if (account == null || account.getRole() != Role.PHOTOGRAPHER || !photographerId.equals(account.getId())) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "본인 계정으로만 수정할 수 있습니다.");
         }
     }
 

--- a/src/main/java/com/pickkasso/pickkasso/item/controller/ServiceRegisterController.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/controller/ServiceRegisterController.java
@@ -8,13 +8,11 @@ import com.pickkasso.pickkasso.user.service.PhotographerProfileService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
+import java.util.List;
 import java.util.Map;
 
 @Controller
@@ -66,6 +64,7 @@ public class ServiceRegisterController {
         model.addAttribute("photographerId", photographerId);
         model.addAttribute("tagList", tagService.findAllTagReference());
         model.addAttribute("itemRegisterRequest", new ItemRegisterRequest());
+        model.addAttribute("formAction", "/photographer/" + photographerId + "/service/new");
         return "photographer/service-register";
     }
 
@@ -73,15 +72,52 @@ public class ServiceRegisterController {
     public String registerService(
         @PathVariable Long photographerId,
         @ModelAttribute ItemRegisterRequest itemRegisterRequest,
+        @RequestParam(required = false) List<String> keptImgUrls,
+        @RequestParam(required = false) List<Integer> keptImgOrders,
+        @RequestParam(required = false) List<MultipartFile> newFiles,
+        @RequestParam(required = false) List<Integer> newFileOrders,
         RedirectAttributes redirectAttributes) {
 
         try {
-            Long itemId = itemService.registerItem(photographerId, itemRegisterRequest);
+            Long itemId = itemService.registerItem(photographerId, itemRegisterRequest, newFiles, newFileOrders);
             redirectAttributes.addFlashAttribute("successMessage", "서비스가 등록되었습니다.");
             return "redirect:/photographer/" + photographerId + "/profile";
         } catch (Exception e) {
             redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
             return "redirect:/photographer/" + photographerId + "/service/new";
+        }
+    }
+
+
+    @GetMapping("/{itemId}/edit")
+    public String serviceEditForm(@PathVariable Long photographerId, @PathVariable Long itemId, Model model) {
+        model.addAttribute("photographerId", photographerId);
+        model.addAttribute("tagList", tagService.findAllTagReference());
+        model.addAttribute("itemRegisterRequest", itemService.getItemRegisterRequest(photographerId, itemId));
+        model.addAttribute("itemImgList", itemService.getItemImage(photographerId, itemId));
+        model.addAttribute("formAction", "/photographer/" + photographerId + "/service/edit");
+        return "photographer/service-register";
+    }
+
+
+    @PostMapping("/{itemId}/edit")
+    public String updateService(
+        @PathVariable Long photographerId,
+        @PathVariable Long itemId,
+        @ModelAttribute ItemRegisterRequest itemRegisterRequest,
+        @RequestParam(required = false) List<String> keptImgUrls,
+        @RequestParam(required = false) List<Integer> keptImgOrders,
+        @RequestParam(required = false) List<MultipartFile> newFiles,
+        @RequestParam(required = false) List<Integer> newFileOrders,
+        RedirectAttributes redirectAttributes) {
+
+        try {
+            itemService.updateItem(photographerId, itemId, itemRegisterRequest, keptImgUrls, keptImgOrders, newFiles, newFileOrders);
+            redirectAttributes.addFlashAttribute("successMessage", "서비스가 수정되었습니다.");
+            return "redirect:/photographer/" + photographerId + "/" + itemId;
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute("errorMessage", e.getMessage());
+            return "redirect:/photographer/" + photographerId + "/" + itemId + "/edit";
         }
     }
 }

--- a/src/main/java/com/pickkasso/pickkasso/item/dto/ItemBoxDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/dto/ItemBoxDto.java
@@ -33,7 +33,7 @@ public class ItemBoxDto {
         return ItemBoxDto.builder()
             .id(item.getId())
             .name(item.getName())
-            // .imgUrl() 미구현
+            .imgUrl(item.getThumbnailImgUrl())
             .tag(TagReference.from(item.getTag()))
             .photographer(PhotographerSimpleCardDto.from(item.getPhotographer()))
             .region(RegionDto.from(item))

--- a/src/main/java/com/pickkasso/pickkasso/item/dto/ItemRegisterRequest.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/dto/ItemRegisterRequest.java
@@ -1,6 +1,7 @@
 package com.pickkasso.pickkasso.item.dto;
 
 import com.pickkasso.pickkasso.item.entity.ItemType;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -11,6 +12,7 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class ItemRegisterRequest {
     private String tagName;
     private ItemType itemType;

--- a/src/main/java/com/pickkasso/pickkasso/item/dto/PlanRegisterRequest.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/dto/PlanRegisterRequest.java
@@ -1,5 +1,6 @@
 package com.pickkasso.pickkasso.item.dto;
 
+import com.pickkasso.pickkasso.item.entity.PlanType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +12,8 @@ import lombok.Setter;
 @AllArgsConstructor
 public class PlanRegisterRequest {
     private String planName;
+    private PlanType planType;
+    private Boolean enabled;
     private Integer shootingDuration;
     private Integer originalPhotoCount;
     private Integer editedPhotoCount;

--- a/src/main/java/com/pickkasso/pickkasso/item/dto/PlanRegisterRequest.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/dto/PlanRegisterRequest.java
@@ -1,5 +1,6 @@
 package com.pickkasso.pickkasso.item.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -7,6 +8,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
+@AllArgsConstructor
 public class PlanRegisterRequest {
     private String planName;
     private Integer shootingDuration;

--- a/src/main/java/com/pickkasso/pickkasso/item/entity/Item.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/entity/Item.java
@@ -129,6 +129,30 @@ public class Item extends Region {
         return item;
     }
 
+    public void updateItem(
+        Tag tag,
+        String name,
+        String description,
+        String includes,
+        String excludes,
+        ItemType itemType,
+        Integer minBookingLeadTime,
+        String cancellationPolicy,
+        String address,
+        Double lat,
+        Double lng) {
+        this.tag = tag;
+        this.name = name;
+        this.description = description;
+        this.includes = includes;
+        this.excludes = excludes;
+        this.itemType = itemType;
+        this.minBookingLeadTime = minBookingLeadTime;
+        this.cancellationPolicy = cancellationPolicy;
+        this.initRegion(address, "", lat, lng);
+    }
+
+
     // plan
     public void addPlan(Plan plan) {
         planList.add(plan);

--- a/src/main/java/com/pickkasso/pickkasso/item/entity/Item.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/entity/Item.java
@@ -49,6 +49,9 @@ public class Item extends Region {
     @Enumerated(EnumType.STRING)
     private ItemType itemType;
 
+    @Column(name = "thumbnail_img_url", length = 500)
+    private String thumbnailImgUrl;
+
     // review와 연계해서 자동으로 계산해야 합니다.
     @Column(name = "review_count", nullable = false)
     private Integer reviewCount;
@@ -164,6 +167,7 @@ public class Item extends Region {
 
     public void updateDefaultPrice() {
         defaultPrice = planList.stream()
+            .filter(p -> p.getEnabled() == true)
             .mapToInt(Plan::getPrice)
             .min()
             .orElse(0);
@@ -179,6 +183,11 @@ public class Item extends Region {
     public void updateItemImgList(List<ItemImg> newItemImgList) {
         itemImgList.clear();
         itemImgList.addAll(newItemImgList);
+        this.thumbnailImgUrl = newItemImgList.stream()
+            .filter(img -> img.getImgOrder() == 0)
+            .map(ItemImg::getImgUrl)
+            .findFirst()
+            .orElse(null);
     }
 
     // item notice

--- a/src/main/java/com/pickkasso/pickkasso/item/entity/Plan.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/entity/Plan.java
@@ -19,6 +19,13 @@ public class Plan {
     @JoinColumn(name = "item_id", nullable = false)
     private Item item;
 
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "plan_type")
+    private PlanType planType;
+
+    @Column(name = "enabled")
+    private Boolean enabled;
+
     @Column(name = "name")
     private String name;
 
@@ -39,6 +46,8 @@ public class Plan {
 
     private Plan(
         Item item,
+        PlanType planType,
+        Boolean enabled,
         String name,
         Integer price,
         Integer shootingDuration,
@@ -46,6 +55,8 @@ public class Plan {
         Integer editedPhotoCount,
         Integer deliveryDays) {
 
+        this.planType = planType;
+        this.enabled = (enabled != null) ? enabled : false;
         this.item = item;
         this.name = name;
         this.price = price;
@@ -58,6 +69,8 @@ public class Plan {
     //== 생성 method ==//
     public static Plan createPlan(
         Item item,
+        PlanType planType,
+        Boolean enabled,
         String name,
         Integer price,
         Integer shootingDuration,
@@ -65,12 +78,30 @@ public class Plan {
         Integer editedPhotoCount,
         Integer deliveryDays) {
 
-        Plan plan = new Plan(item, name, price, shootingDuration, originalPhotoCount, editedPhotoCount, deliveryDays);
+        Plan plan = new Plan(item, planType, enabled, name, price, shootingDuration, originalPhotoCount, editedPhotoCount, deliveryDays);
         plan.item.addPlan(plan);
         plan.item.updateDefaultPrice();
 
         return plan;
     }
+
+    public void updatePlan(
+        Boolean enabled,
+        String name,
+        Integer price,
+        Integer shootingDuration,
+        Integer originalPhotoCount,
+        Integer editedPhotoCount,
+        Integer deliveryDays) {
+        this.enabled = enabled;
+        this.name = name;
+        setPrice(price);
+        this.shootingDuration = shootingDuration;
+        this.originalPhotoCount = originalPhotoCount;
+        this.editedPhotoCount = editedPhotoCount;
+        this.deliveryDays = deliveryDays;
+    }
+
 
     public void setPrice(Integer price) {
         this.price = price;

--- a/src/main/java/com/pickkasso/pickkasso/item/entity/PlanType.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/entity/PlanType.java
@@ -1,0 +1,14 @@
+package com.pickkasso.pickkasso.item.entity;
+
+public enum PlanType {
+    STANDARD(1), DELUXE(2), PREMIUM(3);
+
+    private final int order;
+    PlanType(int order) {
+        this.order = order;
+    }
+
+    public int getOrder() {
+        return order;
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepository.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepository.java
@@ -51,4 +51,15 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
            "WHERE i.photographer.id = :photographerId")
     List<String> findAddressByPhotographerId(@Param("photographerId") Long photographerId);
 
+    @Query("SELECT i FROM Item i " +
+           "JOIN FETCH i.tag " +
+           "LEFT JOIN FETCH i.planList " +
+           "WHERE i.id = :itemId " +
+           "    AND i.photographer.id = :photographerId")
+    Optional<Item> findByIdAndPhotographerId(@Param("itemId") Long itemId, @Param("photographerId") Long photographerId);
+
+    @Query("SELECT i FROM Item i " +
+        "LEFT JOIN FETCH i.itemImgList " +
+        "WHERE i.id = :itemId")
+    Optional<Item> findByIdWithImgList(@Param("itemId") Long itemId);
 }

--- a/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepository.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepository.java
@@ -62,4 +62,9 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
         "LEFT JOIN FETCH i.itemImgList " +
         "WHERE i.id = :itemId")
     Optional<Item> findByIdWithImgList(@Param("itemId") Long itemId);
+
+    @Query("SELECT i FROM Item i " +
+        "LEFT JOIN FETCH i.tag " +
+        "WHERE i.photographer.id = :photographerId ")
+    List<Item> findItemByPhotographerId(@Param("photographerId") Long photographerId);
 }

--- a/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepositoryCustom.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepositoryCustom.java
@@ -4,6 +4,8 @@ import com.pickkasso.pickkasso.item.dto.ItemBoxDto;
 import com.pickkasso.pickkasso.item.dto.ItemSearchCondition;
 import org.springframework.data.domain.Page;
 
+import java.util.List;
+
 public interface ItemRepositoryCustom {
     Page<ItemBoxDto> getSearchItemPage(ItemSearchCondition condition, int pageSize);
 }

--- a/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepositoryCustomImpl.java
@@ -98,7 +98,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
                 ItemBoxDto.class,
                 item.id,
                 item.name,
-                Expressions.nullExpression(String.class),
+                item.thumbnailImgUrl,
                 new QTagReference(item.tag.id, item.tag.name, item.tag.emoji),
                 new QPhotographerSimpleCardDto(Expressions.nullExpression(String.class), item.photographer.name),
                 new QRegionDto(item.address, item.detailAddress, item.lat, item.lng),

--- a/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepositoryCustomImpl.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/repository/ItemRepositoryCustomImpl.java
@@ -99,7 +99,7 @@ public class ItemRepositoryCustomImpl implements ItemRepositoryCustom {
                 item.id,
                 item.name,
                 Expressions.nullExpression(String.class),
-                new QTagReference(item.tag.id, item.tag.name),
+                new QTagReference(item.tag.id, item.tag.name, item.tag.emoji),
                 new QPhotographerSimpleCardDto(Expressions.nullExpression(String.class), item.photographer.name),
                 new QRegionDto(item.address, item.detailAddress, item.lat, item.lng),
                 item.avgScore,

--- a/src/main/java/com/pickkasso/pickkasso/item/repository/PlanRepository.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/repository/PlanRepository.java
@@ -1,0 +1,22 @@
+package com.pickkasso.pickkasso.item.repository;
+
+import com.pickkasso.pickkasso.item.entity.Plan;
+import com.pickkasso.pickkasso.item.entity.PlanType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+    @Query("SELECT p FROM Plan p " +
+        "WHERE p.item.id = :itemId " +
+        "AND p.planType = :planType ")
+    Optional<Plan> findByItemIdAndPlanType(@Param("itemId") Long itemId, @Param("planType") PlanType planType);
+
+    @Query("SELECT p FROM Plan p " +
+        "WHERE p.item.id = :itemId " +
+        "AND p.enabled = true")
+    List<Plan> findByItemIdAndEnabled(@Param("itemId") Long itemId);
+}

--- a/src/main/java/com/pickkasso/pickkasso/item/service/ItemService.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/service/ItemService.java
@@ -2,8 +2,10 @@ package com.pickkasso.pickkasso.item.service;
 
 import com.pickkasso.pickkasso.global.city.City;
 import com.pickkasso.pickkasso.global.img.DefaultImgDto;
+import com.pickkasso.pickkasso.global.region.RegionDto;
 import com.pickkasso.pickkasso.global.service.DefaultImgService;
 import com.pickkasso.pickkasso.global.tag.Tag;
+import com.pickkasso.pickkasso.global.tag.TagReference;
 import com.pickkasso.pickkasso.global.tag.TagRepository;
 import com.pickkasso.pickkasso.item.dto.ItemBoxDto;
 import com.pickkasso.pickkasso.item.dto.ItemRegisterRequest;
@@ -16,6 +18,7 @@ import com.pickkasso.pickkasso.item.repository.ItemRepository;
 import com.pickkasso.pickkasso.user.entity.Photographer;
 import com.pickkasso.pickkasso.user.repository.PhotographerRepository;
 import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -33,6 +36,7 @@ public class ItemService {
     private final PhotographerRepository photographerRepository;
     private final TagRepository tagRepository;
     private final DefaultImgService defaultImgService;
+    private final PlanService planService;
 
     @Transactional(readOnly = true)
     public List<ItemBoxDto> getScoreItemList(Integer count) {
@@ -83,6 +87,8 @@ public class ItemService {
         for (Plan plan : item.getPlanList()) {
             planRegisterRequestList.add(new PlanRegisterRequest(
                 plan.getName(),
+                plan.getPlanType(),
+                plan.getEnabled(),
                 plan.getShootingDuration(),
                 plan.getOriginalPhotoCount(),
                 plan.getEditedPhotoCount(),
@@ -119,6 +125,7 @@ public class ItemService {
         String dirName = "photographer/user_" + photographerId + "/service";
         List<DefaultImgDto> imgDtoList = defaultImgService.uploadImages(newFiles, newFileOrders, dirName);
 
+
         Item item = Item.createItem(
             photographer,
             tag,
@@ -134,17 +141,12 @@ public class ItemService {
             request.getLng()
         );
 
+        System.out.println("complete create item");
+        System.out.println();
         if (request.getPlans() != null) {
             for (PlanRegisterRequest planReq : request.getPlans()) {
-                Plan.createPlan(
-                    item,
-                    planReq.getPlanName(),
-                    planReq.getPrice() != null ? planReq.getPrice() : 0,
-                    planReq.getShootingDuration() != null ? planReq.getShootingDuration() : 1,
-                    planReq.getOriginalPhotoCount() != null ? planReq.getOriginalPhotoCount() : 0,
-                    planReq.getEditedPhotoCount() != null ? planReq.getEditedPhotoCount() : 0,
-                    planReq.getDeliveryDays() != null ? planReq.getDeliveryDays() : 3
-                );
+                Plan plan = planService.savePlan(item, planReq);
+                System.out.println("complete create plan " + plan.getPlanType());
             }
         }
 
@@ -182,7 +184,9 @@ public class ItemService {
             request.getLng()
         );
 
-
+        for (PlanRegisterRequest plan : request.getPlans()) {
+            planService.savePlan(item, plan);
+        }
 
         item.updateItemImgList(toItemImgList(item, imgDtoList));
         item.updateDefaultPrice();
@@ -237,6 +241,27 @@ public class ItemService {
             .limit(3)
             .map(Map.Entry::getKey)
             .forEach(resList::add);
+        return resList;
+    }
+
+    public List<ItemBoxDto> getItemBoxDtoById(Long photographerId) {
+        List<Item> items = itemRepository.findItemByPhotographerId(photographerId);
+        tagRepository.findAllTagReference();
+        List<ItemBoxDto> resList = new ArrayList<>();
+        for (Item item : items) {
+            ItemBoxDto dto = ItemBoxDto.builder()
+                .id(item.getId())
+                .name(item.getName())
+                .imgUrl(item.getThumbnailImgUrl())
+                .tag(TagReference.from(item.getTag()))
+                .region(RegionDto.from(item))
+                .avgScore(item.getAvgScore())
+                .defaultPrice(item.getDefaultPrice())
+                .itemType(item.getItemType())
+                .reviewCount(item.getReviewCount())
+                .build();
+            resList.add(dto);
+        }
         return resList;
     }
 }

--- a/src/main/java/com/pickkasso/pickkasso/item/service/ItemService.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/service/ItemService.java
@@ -1,6 +1,8 @@
 package com.pickkasso.pickkasso.item.service;
 
 import com.pickkasso.pickkasso.global.city.City;
+import com.pickkasso.pickkasso.global.img.DefaultImgDto;
+import com.pickkasso.pickkasso.global.service.DefaultImgService;
 import com.pickkasso.pickkasso.global.tag.Tag;
 import com.pickkasso.pickkasso.global.tag.TagRepository;
 import com.pickkasso.pickkasso.item.dto.ItemBoxDto;
@@ -8,6 +10,7 @@ import com.pickkasso.pickkasso.item.dto.ItemRegisterRequest;
 import com.pickkasso.pickkasso.item.dto.ItemSearchCondition;
 import com.pickkasso.pickkasso.item.dto.PlanRegisterRequest;
 import com.pickkasso.pickkasso.item.entity.Item;
+import com.pickkasso.pickkasso.item.entity.ItemImg;
 import com.pickkasso.pickkasso.item.entity.Plan;
 import com.pickkasso.pickkasso.item.repository.ItemRepository;
 import com.pickkasso.pickkasso.user.entity.Photographer;
@@ -18,6 +21,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.*;
 
@@ -28,6 +32,7 @@ public class ItemService {
     private final ItemRepository itemRepository;
     private final PhotographerRepository photographerRepository;
     private final TagRepository tagRepository;
+    private final DefaultImgService defaultImgService;
 
     @Transactional(readOnly = true)
     public List<ItemBoxDto> getScoreItemList(Integer count) {
@@ -50,12 +55,69 @@ public class ItemService {
         return itemRepository.getSearchItemPage(condition, pageSize);
     }
 
-    public Long registerItem(Long photographerId, ItemRegisterRequest request) {
+    private List<ItemImg> toItemImgList(Item item, List<DefaultImgDto> imgDtoList) {
+        if (imgDtoList == null || imgDtoList.isEmpty()) return new ArrayList<>();
+        return imgDtoList.stream()
+            .map(dto -> ItemImg.createItemImg(
+                item,
+                dto.getImgUrl(),
+                dto.getImgOrder()
+            ))
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<DefaultImgDto> getItemImage(Long photographerId, Long itemId) {
+        Item item = itemRepository.findByIdWithImgList(itemId)
+            .orElseThrow(() -> new IllegalArgumentException("해당 작가의 서비스가 아닙니다."));
+        return item.getItemImgList().stream()
+            .map(DefaultImgDto::from)
+            .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public ItemRegisterRequest getItemRegisterRequest(Long photographerId, Long itemId) {
+        Item item = itemRepository.findByIdAndPhotographerId(itemId, photographerId)
+            .orElseThrow(() -> new IllegalArgumentException("해당 작가의 서비스가 아닙니다."));
+        List<PlanRegisterRequest> planRegisterRequestList = new ArrayList<>();
+        for (Plan plan : item.getPlanList()) {
+            planRegisterRequestList.add(new PlanRegisterRequest(
+                plan.getName(),
+                plan.getShootingDuration(),
+                plan.getOriginalPhotoCount(),
+                plan.getEditedPhotoCount(),
+                plan.getDeliveryDays(),
+                plan.getPrice()
+            ));
+        }
+
+        ItemRegisterRequest request = new ItemRegisterRequest(
+            item.getTag().getName(),
+            item.getItemType(),
+            item.getName(),
+            item.getDescription(),
+            item.getIncludes(),
+            item.getExcludes(),
+            item.getAddress(),
+            item.getLat(),
+            item.getLng(),
+            item.getMinBookingLeadTime(),
+            item.getCancellationPolicy(),
+            planRegisterRequestList
+        );
+        return request;
+    }
+
+    public Long registerItem(Long photographerId, ItemRegisterRequest request, List<MultipartFile> newFiles, List<Integer> newFileOrders) {
         Photographer photographer = photographerRepository.findById(photographerId)
             .orElseThrow(() -> new IllegalArgumentException("작가를 찾을 수 없습니다."));
 
         Tag tag = tagRepository.findTagByName(request.getTagName())
             .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다: " + request.getTagName()));
+
+        // image upload + save
+        String dirName = "photographer/user_" + photographerId + "/service";
+        List<DefaultImgDto> imgDtoList = defaultImgService.uploadImages(newFiles, newFileOrders, dirName);
 
         Item item = Item.createItem(
             photographer,
@@ -86,8 +148,44 @@ public class ItemService {
             }
         }
 
+        item.updateItemImgList(toItemImgList(item, imgDtoList));
         item.updateDefaultPrice();
         return itemRepository.save(item).getId();
+    }
+
+    public void updateItem(Long photographerId, Long itemId, ItemRegisterRequest request, List<String> keptImgUrls, List<Integer> keptImgOrders, List<MultipartFile> newFiles, List<Integer> newFileOrders) {
+        Photographer photographer = photographerRepository.findById(photographerId)
+            .orElseThrow(() -> new IllegalArgumentException("작가를 찾을 수 없습니다."));
+
+        Tag tag = tagRepository.findTagByName(request.getTagName())
+            .orElseThrow(() -> new IllegalArgumentException("카테고리를 찾을 수 없습니다: " + request.getTagName()));
+
+        Item item = itemRepository.findByIdAndPhotographerId(itemId, photographerId)
+            .orElseThrow(() -> new IllegalArgumentException("해당 작가의 서비스가 아닙니다."));
+        itemRepository.findByIdWithImgList(itemId);
+
+        // image upload + save
+        String dirName = "photographer/user_" + photographerId + "/service";
+        List<DefaultImgDto> imgDtoList = defaultImgService.updateImages(item.getItemImgList(), keptImgUrls, keptImgOrders, newFiles, newFileOrders, dirName);
+
+        item.updateItem(
+            tag,
+            request.getName(),
+            request.getDescription() != null ? request.getDescription() : "",
+            request.getIncludes(),
+            request.getExcludes(),
+            request.getItemType(),
+            request.getMinBookingLeadTime() != null ? request.getMinBookingLeadTime() : 1,
+            request.getCancellationPolicy(),
+            request.getAddress(),
+            request.getLat(),
+            request.getLng()
+        );
+
+
+
+        item.updateItemImgList(toItemImgList(item, imgDtoList));
+        item.updateDefaultPrice();
     }
 
     private List<ItemBoxDto> getItemBoxDtoList(List<Item> itemList) {
@@ -128,7 +226,11 @@ public class ItemService {
         List<String> addressList = itemRepository.findAddressByPhotographerId(photographerId);
 
         for (String address : addressList) {
-            resMap.merge(City.fromString(address), 1, Integer::sum);
+            try {
+                resMap.merge(City.fromString(address), 1, Integer::sum);
+            } catch (Exception ignored) {
+
+            }
         }
         resMap.entrySet().stream()
             .sorted(Map.Entry.<City, Integer>comparingByValue().reversed())

--- a/src/main/java/com/pickkasso/pickkasso/item/service/PlanService.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/service/PlanService.java
@@ -1,0 +1,61 @@
+package com.pickkasso.pickkasso.item.service;
+
+import com.pickkasso.pickkasso.item.dto.PlanRegisterRequest;
+import com.pickkasso.pickkasso.item.entity.Item;
+import com.pickkasso.pickkasso.item.entity.Plan;
+import com.pickkasso.pickkasso.item.repository.PlanRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PlanService {
+
+    private final PlanRepository planRepository;
+
+    @Transactional(readOnly = true)
+    public List<Plan> getEnabledPlans(Long itemId) {
+        List<Plan> resList =  planRepository.findByItemIdAndEnabled(itemId);
+        resList.sort(Comparator.comparing(p -> p.getPlanType().getOrder()));
+        return resList;
+    }
+
+    public Plan savePlan(Item item, PlanRegisterRequest request) {
+        Plan plan = planRepository.findByItemIdAndPlanType(item.getId(), request.getPlanType())
+            .orElseGet(() -> {
+                Plan p = Plan.createPlan(
+                    item,
+                    request.getPlanType(),
+                    request.getEnabled() != null ? request.getEnabled() : false,
+                    request.getPlanName() != null ? request.getPlanName() : request.getPlanType().toString(),
+                    request.getPrice() != null ? request.getPrice() : 1_000_000,
+                    request.getShootingDuration() != null ? request.getShootingDuration() : 1,
+                    request.getOriginalPhotoCount() != null ? request.getOriginalPhotoCount() : 0,
+                    request.getEditedPhotoCount() != null ? request.getEditedPhotoCount() : 0,
+                    request.getDeliveryDays() != null ? request.getDeliveryDays() : 3
+                );
+                p.getItem().addPlan(p);
+                return p;
+            });
+        // update
+        if (plan.getId() != null) {
+            plan.updatePlan(
+                request.getEnabled() != null ? request.getEnabled() : false,
+                request.getPlanName() != null ? request.getPlanName() : request.getPlanType().toString(),
+                request.getPrice() != null ? request.getPrice() : 1_000_000,
+                request.getShootingDuration() != null ? request.getShootingDuration() : 1,
+                request.getOriginalPhotoCount() != null ? request.getOriginalPhotoCount() : 0,
+                request.getEditedPhotoCount() != null ? request.getEditedPhotoCount() : 0,
+                request.getDeliveryDays() != null ? request.getDeliveryDays() : 3
+            );
+            plan = planRepository.save(plan);
+        }
+
+        return plan;
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerProfileController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerProfileController.java
@@ -27,7 +27,7 @@ public class PhotographerProfileController {
     public String profilePage(@PathVariable Long photographerId, Model model, Authentication authentication) {
         PhotographerProfileResponse response = photographerProfileService.getProfileForm(photographerId);
         model.addAttribute("profile", response);
-        model.addAttribute("items", itemService.getItemsByPhotographerId(photographerId));
+        model.addAttribute("items", itemService.getItemBoxDtoById(photographerId));
 
         boolean isOwner = false;
         if (authentication != null && authentication.isAuthenticated()) {

--- a/src/main/resources/templates/fragments/modal/location-modal-for-item.html
+++ b/src/main/resources/templates/fragments/modal/location-modal-for-item.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<th:block th:fragment="locationModal(regionInputId, latInputId, lngInputId, displayId, clearBtnId)">
+
+  <div id="location-modal"
+       style="display:none; position:fixed; inset:0; background:rgba(0,0,0,0.45); z-index:1000; align-items:center; justify-content:center;">
+    <div style="background:#fff; border-radius:12px; width:920px; padding:28px 28px 20px;">
+
+      <h2 style="font-size:18px; font-weight:500; margin:0 0 20px;">위치 선택</h2>
+
+      <!-- 본문 -->
+      <div style="display:flex; gap:16px; height:560px;">
+
+        <!-- 지도 -->
+        <div id="kakao-map" style="flex:0 0 460px; height:100%; border-radius:8px; overflow:hidden;"></div>
+
+        <!-- 오른쪽 패널 -->
+        <div style="flex:1; position:relative; display:flex; flex-direction:column; gap:12px;">
+          <div style="flex:1; border:1px solid #eee; border-radius:12px; padding:16px; display:flex; flex-direction:column; justify-content:center;">
+
+            <!-- 선택 전 -->
+            <div id="direct-empty" style="display:flex; flex-direction:column; align-items:center; gap:12px;">
+              <p style="margin:0; color:#aaa; font-size:13px; text-align:center;">
+                지도를 클릭해서 위치를 선택하거나<br>주소로 검색하세요
+              </p>
+              <button type="button" onclick="locationModal.openPostcode()"
+                      style="padding:8px 20px; background:#fff; border:1px solid #1D3CFF; color:#1D3CFF; border-radius:8px; font-size:13px; cursor:pointer;">
+                주소로 검색하기
+              </button>
+            </div>
+
+            <!-- 선택 후 -->
+            <div id="direct-filled" style="display:none; flex-direction:column; gap:4px;">
+              <p style="font-size:12px; color:#888; margin:0 0 2px;">도로명 주소</p>
+              <p id="direct-road"   style="font-size:14px; font-weight:500; margin:0 0 12px; color:#333;"></p>
+              <p style="font-size:12px; color:#888; margin:0 0 2px;">지번 주소</p>
+              <p id="direct-jibun"  style="font-size:13px; margin:0 0 12px; color:#555;"></p>
+              <p style="font-size:12px; color:#888; margin:0 0 2px;">지역</p>
+              <p id="direct-region" style="font-size:13px; margin:0 0 16px; color:#555;"></p>
+              <button type="button" onclick="locationModal.openPostcode()"
+                      style="width:100%; padding:8px; background:#fff; border:1px solid #ddd; color:#555; border-radius:8px; font-size:12px; cursor:pointer;">
+                다시 검색하기
+              </button>
+            </div>
+          </div>
+
+          <!-- 우편번호 오버레이 -->
+          <div id="postcode-overlay"
+               style="display:none; position:absolute; inset:0; background:#fff; border-radius:12px; z-index:10; flex-direction:column; overflow:hidden;">
+            <div style="display:flex; align-items:center; justify-content:space-between; padding:14px 16px; border-bottom:1px solid #eee; flex-shrink:0;">
+              <span style="font-size:14px; font-weight:500;">주소 검색</span>
+              <button type="button" onclick="locationModal.closePostcode()"
+                      style="background:none; border:none; font-size:18px; color:#888; cursor:pointer; line-height:1;">&#x2715;</button>
+            </div>
+            <div id="postcode-wrap" style="flex:1; min-height:0; overflow:hidden;"></div>
+          </div>
+
+        </div>
+      </div>
+
+      <!-- 하단 버튼 -->
+      <div style="border-top:1px solid #eee; margin-top:20px; padding-top:16px; display:flex; justify-content:flex-end; gap:8px;">
+        <button type="button" onclick="locationModal.close()"
+                style="padding:8px 20px; border:1px solid #ddd; border-radius:8px; background:#fff; cursor:pointer;">취소</button>
+        <button type="button" id="btn-confirm-location" onclick="locationModal.confirm()"
+                style="padding:8px 20px; background:#1D3CFF; color:#fff; border:none; border-radius:8px; opacity:0.4; cursor:default;" disabled>선택 완료</button>
+      </div>
+
+    </div>
+  </div>
+
+  <script th:inline="javascript">
+      kakao.maps.load(function () {
+          const _regionInputId = /*[[${regionInputId}]]*/ 'h-region';
+          const _latInputId    = /*[[${latInputId}]]*/ 'h-lat';
+          const _lngInputId    = /*[[${lngInputId}]]*/ 'h-lng';
+          const _displayId     = /*[[${displayId}]]*/ 'display-region';
+          const _clearBtnId    = /*[[${clearBtnId}]]*/ 'clear-region-btn';
+
+          const locationModal = {
+              selectedData: null,
+              map: null,
+              marker: null,
+
+              open() {
+                  document.getElementById('location-modal').style.display = 'flex';
+                  this.initMap();
+              },
+
+              close() {
+                  document.getElementById('location-modal').style.display = 'none';
+              },
+
+              initMap() {
+                  if (this.map) return;
+                  const container = document.getElementById('kakao-map');
+                  this.map = new kakao.maps.Map(container, {
+                      center: new kakao.maps.LatLng(37.5665, 126.9780),
+                      level: 5,
+                  });
+                  this.marker = new kakao.maps.Marker();
+                  this.mapClickHandler = (mouseEvent) => {
+                      this.selectByClick(mouseEvent.latLng.getLat(), mouseEvent.latLng.getLng());
+                  };
+                  kakao.maps.event.addListener(this.map, 'click', this.mapClickHandler);
+              },
+
+              selectByClick(lat, lng) {
+                  const position = new kakao.maps.LatLng(lat, lng);
+                  this.marker.setPosition(position);
+                  this.marker.setMap(this.map);
+
+                  const geocoder = new kakao.maps.services.Geocoder();
+                  geocoder.coord2Address(lng, lat, (result, status) => {
+                      if (status !== kakao.maps.services.Status.OK) return;
+                      const road   = result[0].road_address?.address_name || '';
+                      const jibun  = result[0].address?.address_name || '';
+                      const r      = result[0].address;
+                      const region = [r?.region_1depth_name, r?.region_2depth_name, r?.region_3depth_name]
+                          .filter(Boolean).join(' ');
+
+                      document.getElementById('direct-empty').style.display  = 'none';
+                      document.getElementById('direct-filled').style.display = 'flex';
+                      document.getElementById('direct-road').textContent     = road || jibun;
+                      document.getElementById('direct-jibun').textContent    = jibun;
+                      document.getElementById('direct-region').textContent   = region;
+
+                      this.selectedData = { region, lat, lng };
+                      this.setConfirmEnabled(true);
+                  });
+              },
+
+              openPostcode() {
+                  const overlay = document.getElementById('postcode-overlay');
+                  overlay.style.display = 'flex';
+                  document.getElementById('postcode-wrap').innerHTML = '';
+
+                  new daum.Postcode({
+                      width: '100%',
+                      height: '100%',
+                      oncomplete: (data) => {
+                          const fullAddress = data.roadAddress || data.jibunAddress;
+                          const region = [data.sido, data.sigungu, data.bname].filter(Boolean).join(' ');
+
+                          new kakao.maps.services.Geocoder().addressSearch(fullAddress, (result, status) => {
+                              if (status !== kakao.maps.services.Status.OK) return;
+
+                              const lat = parseFloat(result[0].y);
+                              const lng = parseFloat(result[0].x);
+
+                              document.getElementById('direct-empty').style.display  = 'none';
+                              document.getElementById('direct-filled').style.display = 'flex';
+                              document.getElementById('direct-road').textContent     = data.roadAddress || '';
+                              document.getElementById('direct-jibun').textContent    = data.jibunAddress || '';
+                              document.getElementById('direct-region').textContent   = region;
+
+                              this.selectedData = { region, lat, lng };
+                              this.moveMap(lat, lng);
+                              this.setConfirmEnabled(true);
+                              this.closePostcode();
+                          });
+                      }
+                  }).embed(document.getElementById('postcode-wrap'));
+              },
+
+              closePostcode() {
+                  document.getElementById('postcode-overlay').style.display = 'none';
+                  document.getElementById('postcode-wrap').innerHTML = '';
+              },
+
+              moveMap(lat, lng) {
+                  const position = new kakao.maps.LatLng(lat, lng);
+                  this.map.panTo(position);
+                  this.marker.setPosition(position);
+                  this.marker.setMap(this.map);
+              },
+
+              setConfirmEnabled(enabled) {
+                  const btn = document.getElementById('btn-confirm-location');
+                  btn.disabled      = !enabled;
+                  btn.style.opacity = enabled ? '1' : '0.4';
+                  btn.style.cursor  = enabled ? 'pointer' : 'default';
+              },
+
+              confirm() {
+                  if (!this.selectedData) return;
+
+                  document.getElementById(_regionInputId).value = this.selectedData.region;
+                  document.getElementById(_latInputId).value    = this.selectedData.lat;
+                  document.getElementById(_lngInputId).value    = this.selectedData.lng;
+
+                  const displayEl = document.getElementById(_displayId);
+                  displayEl.textContent = this.selectedData.region;
+                  displayEl.classList.remove('text-[#AAA]');
+                  displayEl.classList.add('text-[#1A1A1A]');
+
+                  const clearBtn = document.getElementById(_clearBtnId);
+                  if (clearBtn) clearBtn.classList.remove('hidden');
+
+                  if (typeof updateProgressSidebar === 'function') updateProgressSidebar();
+
+                  this.close();
+              },
+          };
+
+          window.locationModal = locationModal;
+      });
+
+      window.locationModal = locationModal;
+
+      // 버튼 바인딩
+      const openBtn = document.getElementById('btn-open-location-modal');
+      if (openBtn) openBtn.addEventListener('click', () => locationModal.open());
+  </script>
+
+</th:block>
+</body>
+</html>

--- a/src/main/resources/templates/photographer/service-detail.html
+++ b/src/main/resources/templates/photographer/service-detail.html
@@ -95,7 +95,7 @@
           <h2 class="text-xl font-semibold text-[#1A1A1A] mb-4">작가 소개</h2>
 
           <div th:if="${profile.intro != null and !#strings.isEmpty(profile.intro)}"
-               class="text-base text-[#444] leading-8 whitespace-pre-line"
+               class="text-base text-[#444] leading-8 whitespace-pre-line break-words"
                th:text="${profile.intro}"></div>
 
           <div th:unless="${profile.intro != null and !#strings.isEmpty(profile.intro)}"
@@ -163,7 +163,10 @@
                th:if="${stat.index < 6}"
                th:href="@{/photographer/{id}/portfolio/{pid}(id=${profile.photographerId}, pid=${portfolio.portfolioId})}"
                class="rounded-xl overflow-hidden bg-[#D3DEF2] aspect-square flex items-center justify-center text-2xl text-[#888] hover:opacity-80 transition-opacity">
-              🖼️
+              <img th:if="${portfolio.imgUrl != null and !#strings.isEmpty(portfolio.imgUrl)}"
+                   th:src="${portfolio.imgUrl}" alt="포트폴리오"
+                   class="w-full h-full object-cover">
+              <span th:unless="${portfolio.imgUrl != null and !#strings.isEmpty(portfolio.imgUrl)}">🖼️</span>
             </a>
           </div>
 

--- a/src/main/resources/templates/photographer/service-detail.html
+++ b/src/main/resources/templates/photographer/service-detail.html
@@ -32,6 +32,35 @@
     </div>
   </section>
 
+  <!-- ── Item Images ─────────────────────────────────────── -->
+  <section th:if="${itemImgList != null and !itemImgList.isEmpty()}"
+           class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-5">
+    <div class="flex gap-3 h-[420px]">
+
+      <!-- 메인 이미지 -->
+      <div class="flex-1 rounded-2xl overflow-hidden bg-[#D3DEF2]">
+        <img id="main-img"
+             th:src="${itemImgList[0].imgUrl}"
+             alt="대표 이미지"
+             class="w-full h-full object-cover transition-opacity duration-200">
+      </div>
+
+      <!-- 썸네일 목록 (이미지 2장 이상일 때만) -->
+      <div th:if="${#lists.size(itemImgList) > 1}"
+           class="flex flex-col gap-2 w-24 overflow-y-auto">
+        <div th:each="img, stat : ${itemImgList}"
+             class="thumbnail-item flex-shrink-0 h-24 rounded-xl overflow-hidden cursor-pointer border-2 transition-all"
+             th:classappend="${stat.first} ? ' border-[#1D3CFF]' : ' border-transparent hover:border-[#1D3CFF]'"
+             th:attr="data-src=${img.imgUrl}"
+             onclick="selectImg(this)">
+          <img th:src="${img.imgUrl}" alt="썸네일"
+               class="w-full h-full object-cover">
+        </div>
+      </div>
+
+    </div>
+  </section>
+
   <!-- ── Photographer Card ─────────────────────────────── -->
   <section class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-5">
     <div class="bg-white border border-[#CCC] rounded-2xl p-5 sm:p-6">
@@ -370,6 +399,15 @@
         });
       });
     })();
+    function selectImg(el) {
+        document.getElementById('main-img').src = el.dataset.src;
+        document.querySelectorAll('.thumbnail-item').forEach(t => {
+            t.classList.remove('border-[#1D3CFF]');
+            t.classList.add('border-transparent');
+        });
+        el.classList.add('border-[#1D3CFF]');
+        el.classList.remove('border-transparent');
+    }
   </script>
 
 </main>

--- a/src/main/resources/templates/photographer/service-detail.html
+++ b/src/main/resources/templates/photographer/service-detail.html
@@ -213,9 +213,9 @@
         <div class="bg-white border border-[#CCC] rounded-2xl overflow-hidden">
 
           <!-- Tabs -->
-          <div th:if="${item.planList != null and !item.planList.isEmpty()}"
+          <div th:if="${enabledPlans != null and !enabledPlans.isEmpty()}"
                class="flex border-b border-[#CCC]">
-            <button th:each="plan, stat : ${item.planList}"
+            <button th:each="plan, stat : ${enabledPlans}"
                     th:id="'tab-' + ${stat.index}"
                     th:text="${plan.name != null and !#strings.isEmpty(plan.name) ? plan.name : '패키지 ' + (stat.index + 1)}"
                     th:classappend="${stat.first} ? ' border-b-2 border-[#1D3CFF] text-[#1D3CFF]' : ' text-[#888] hover:text-[#444]'"
@@ -225,13 +225,13 @@
             </button>
           </div>
 
-          <div th:if="${item.planList == null or item.planList.isEmpty()}"
+          <div th:if="${enabledPlans == null or enabledPlans.isEmpty()}"
                class="px-5 pt-4 pb-2">
             <p class="text-sm text-[#888]">등록된 패키지가 없습니다.</p>
           </div>
 
           <!-- Plan Panels -->
-          <div th:each="plan, stat : ${item.planList}"
+          <div th:each="plan, stat : ${enabledPlans}"
                th:id="'panel-' + ${stat.index}"
                th:classappend="${!stat.first} ? ' hidden'"
                class="plan-panel p-5">

--- a/src/main/resources/templates/photographer/service-register.html
+++ b/src/main/resources/templates/photographer/service-register.html
@@ -171,43 +171,8 @@
               <th:block th:each="tag : ${tagList}">
                 <label class="category-option relative flex flex-col items-center justify-center gap-2 py-4 px-2.5 bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-xl cursor-pointer text-[13px] font-medium text-[#444] text-center leading-snug transition-all hover:border-[#1D3CFF] hover:bg-[#EEF1FF]">
                   <input type="radio" name="tagName" th:value="${tag.name}" class="absolute opacity-0 w-0 h-0">
-                  <span class="cat-emoji text-2xl" th:text="${categoryEmojis[tag.name] ?: '📷'}">📷</span>
+                  <span class="cat-emoji text-2xl" th:text="${tag.emoji ?: '📷'}">📷</span>
                   <span th:text="${tag.name}">카테고리</span>
-                </label>
-              </th:block>
-              <!-- Fallback if no tags from DB -->
-              <th:block th:if="${#lists.isEmpty(tagList)}">
-                <label class="category-option relative flex flex-col items-center justify-center gap-2 py-4 px-2.5 bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-xl cursor-pointer text-[13px] font-medium text-[#444] text-center leading-snug transition-all hover:border-[#1D3CFF] hover:bg-[#EEF1FF]">
-                  <input type="radio" name="tagName" value="데이트 스냅" class="absolute opacity-0 w-0 h-0">
-                  <span class="text-2xl">🌸</span>데이트 스냅
-                </label>
-                <label class="category-option relative flex flex-col items-center justify-center gap-2 py-4 px-2.5 bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-xl cursor-pointer text-[13px] font-medium text-[#444] text-center leading-snug transition-all hover:border-[#1D3CFF] hover:bg-[#EEF1FF]">
-                  <input type="radio" name="tagName" value="프로필" class="absolute opacity-0 w-0 h-0">
-                  <span class="text-2xl">🤳</span>프로필
-                </label>
-                <label class="category-option relative flex flex-col items-center justify-center gap-2 py-4 px-2.5 bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-xl cursor-pointer text-[13px] font-medium text-[#444] text-center leading-snug transition-all hover:border-[#1D3CFF] hover:bg-[#EEF1FF]">
-                  <input type="radio" name="tagName" value="졸업사진" class="absolute opacity-0 w-0 h-0">
-                  <span class="text-2xl">🎓</span>졸업사진
-                </label>
-                <label class="category-option relative flex flex-col items-center justify-center gap-2 py-4 px-2.5 bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-xl cursor-pointer text-[13px] font-medium text-[#444] text-center leading-snug transition-all hover:border-[#1D3CFF] hover:bg-[#EEF1FF]">
-                  <input type="radio" name="tagName" value="웨딩 스냅" class="absolute opacity-0 w-0 h-0">
-                  <span class="text-2xl">💒</span>웨딩 스냅
-                </label>
-                <label class="category-option relative flex flex-col items-center justify-center gap-2 py-4 px-2.5 bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-xl cursor-pointer text-[13px] font-medium text-[#444] text-center leading-snug transition-all hover:border-[#1D3CFF] hover:bg-[#EEF1FF]">
-                  <input type="radio" name="tagName" value="가족사진" class="absolute opacity-0 w-0 h-0">
-                  <span class="text-2xl">👨‍👩‍👧</span>가족사진
-                </label>
-                <label class="category-option relative flex flex-col items-center justify-center gap-2 py-4 px-2.5 bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-xl cursor-pointer text-[13px] font-medium text-[#444] text-center leading-snug transition-all hover:border-[#1D3CFF] hover:bg-[#EEF1FF]">
-                  <input type="radio" name="tagName" value="증명사진" class="absolute opacity-0 w-0 h-0">
-                  <span class="text-2xl">🪪</span>증명사진
-                </label>
-                <label class="category-option relative flex flex-col items-center justify-center gap-2 py-4 px-2.5 bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-xl cursor-pointer text-[13px] font-medium text-[#444] text-center leading-snug transition-all hover:border-[#1D3CFF] hover:bg-[#EEF1FF]">
-                  <input type="radio" name="tagName" value="반려동물" class="absolute opacity-0 w-0 h-0">
-                  <span class="text-2xl">🐾</span>반려동물
-                </label>
-                <label class="category-option relative flex flex-col items-center justify-center gap-2 py-4 px-2.5 bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-xl cursor-pointer text-[13px] font-medium text-[#444] text-center leading-snug transition-all hover:border-[#1D3CFF] hover:bg-[#EEF1FF]">
-                  <input type="radio" name="tagName" value="제품 촬영" class="absolute opacity-0 w-0 h-0">
-                  <span class="text-2xl">🛍️</span>제품 촬영
                 </label>
               </th:block>
             </div>

--- a/src/main/resources/templates/photographer/service-register.html
+++ b/src/main/resources/templates/photographer/service-register.html
@@ -18,6 +18,10 @@
       }
     }
   </script>
+
+  <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+  <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=66fd58e49ef902c79dbaa2577ceb31d2&libraries=services"></script>
+
 </head>
 <body class="bg-[#F9FAFC] font-sans text-[#1A1A1A]">
 
@@ -237,78 +241,98 @@
 
           <!-- 패키지 테이블 -->
           <div class="border border-[#CCC] rounded-xl overflow-hidden">
-            <!-- 테이블 헤더 -->
-            <div class="grid grid-cols-[2fr_1fr_1fr_1fr_1fr_1.5fr_36px] bg-[#F9FAFC] border-b border-[#CCC] px-4 py-2.5">
+            <div class="grid grid-cols-[auto_2fr_1fr_1fr_1fr_1fr_1.5fr] bg-[#F9FAFC] border-b border-[#CCC] px-4 py-2.5">
+              <div class="text-xs font-bold text-[#888] w-20">플랜</div>
               <div class="text-xs font-bold text-[#888]">패키지명</div>
               <div class="text-xs font-bold text-[#888] text-center">촬영 시간</div>
               <div class="text-xs font-bold text-[#888] text-center">원본 컷</div>
               <div class="text-xs font-bold text-[#888] text-center">보정 컷</div>
               <div class="text-xs font-bold text-[#888] text-center">납품 기간</div>
               <div class="text-xs font-bold text-[#888] text-center">가격</div>
-              <div></div>
             </div>
-            <!-- 패키지 행 목록 -->
-            <div id="plan-list">
-              <th:block th:if="${not #lists.isEmpty(itemRegisterRequest.plans)}"
-                        th:each="plan, stat : ${itemRegisterRequest.plans}">
-                <div class="plan-row grid grid-cols-[2fr_1fr_1fr_1fr_1fr_1.5fr_36px] items-center px-4 py-3.5 border-b border-[#CCC] last:border-b-0 gap-2">
-                  <div class="flex items-center gap-2">
-                    <span class="text-base leading-none flex-shrink-0">📸</span>
-                    <input type="text" th:name="'plans[' + ${stat.index} + '].planName'"
-                           th:value="${plan.planName}" placeholder="패키지명"
-                           class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-2.5 py-1.5 text-[13px] text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] transition-colors">
-                  </div>
-                  <div class="flex items-center justify-center gap-1">
-                    <input type="number" th:name="'plans[' + ${stat.index} + '].shootingDuration'"
-                           th:value="${plan.shootingDuration}" min="1" max="12"
-                           class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
-                    <span class="text-xs text-[#888] flex-shrink-0">시간</span>
-                  </div>
-                  <div class="flex items-center justify-center gap-1">
-                    <input type="number" th:name="'plans[' + ${stat.index} + '].originalPhotoCount'"
-                           th:value="${plan.originalPhotoCount}" min="0"
-                           class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
-                    <span class="text-xs text-[#888] flex-shrink-0">장</span>
-                  </div>
-                  <div class="flex items-center justify-center gap-1">
-                    <input type="number" th:name="'plans[' + ${stat.index} + '].editedPhotoCount'"
-                           th:value="${plan.editedPhotoCount}" min="0"
-                           class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
-                    <span class="text-xs text-[#888] flex-shrink-0">장</span>
-                  </div>
-                  <div class="flex items-center justify-center gap-1">
-                    <input type="number" th:name="'plans[' + ${stat.index} + '].deliveryDays'"
-                           th:value="${plan.deliveryDays}" min="1"
-                           class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
-                    <span class="text-xs text-[#888] flex-shrink-0">일</span>
-                  </div>
-                  <div class="relative flex items-center">
-                    <input type="number" th:name="'plans[' + ${stat.index} + '].price'"
-                           th:value="${plan.price}" placeholder="0" min="0"
-                           class="plan-price w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-2.5 pr-7 py-1.5 text-[13px] text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] transition-colors">
-                    <span class="absolute right-2.5 text-xs text-[#888] pointer-events-none">원</span>
-                  </div>
-                  <div class="flex items-center justify-center">
-                    <button type="button" class="btn-remove-plan w-7 h-7 bg-white border border-[#CCC] rounded-lg flex items-center justify-center text-[#888] hover:border-[#FF4D4D] hover:text-[#FF4D4D] transition-colors flex-shrink-0 invisible"
-                            onclick="removePlan(this)">
-                      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-                    </button>
-                  </div>
+
+            <th:block th:each="planType, stat : ${planTypes}">
+              <div class="plan-row grid grid-cols-[auto_2fr_1fr_1fr_1fr_1fr_1.5fr] items-center px-4 py-3.5 border-b border-[#CCC] last:border-b-0 gap-2"
+                   th:classappend="${!stat.last} ? 'border-b' : ''">
+
+                <!-- planType hidden -->
+                <input type="hidden" th:name="'plans[' + ${stat.index} + '].planType'" th:value="${planType}">
+
+                <!-- 활성화 토글 + 플랜명 -->
+                <div class="flex flex-col items-center gap-1 w-20">
+                <span class="text-[11px] font-bold"
+                      th:classappend="${planType == 'STANDARD'} ? 'text-[#888]' : (${planType == 'DELUXE'} ? 'text-[#0097FF]' : 'text-[#1D3CFF]')"
+                      th:text="${planType}"></span>
+                  <label class="relative inline-flex items-center cursor-pointer">
+                    <input type="checkbox"
+                           th:name="'plans[' + ${stat.index} + '].enabled'"
+                           th:id="'enabled-' + ${planType}"
+                           value="true"
+                           class="sr-only peer plan-toggle"
+                           th:checked="${itemRegisterRequest.plans != null and itemRegisterRequest.plans.size() > stat.index and itemRegisterRequest.plans[stat.index].enabled}">
+                    <div class="w-9 h-5 bg-[#CCC] rounded-full peer peer-checked:bg-[#1D3CFF] transition-colors"></div>
+                    <div class="absolute left-0.5 top-0.5 w-4 h-4 bg-white rounded-full transition-transform peer-checked:translate-x-4"></div>
+                  </label>
                 </div>
-              </th:block>
-              <!-- plans가 비어있을 때 기본 row -->
-              <th:block th:if="${#lists.isEmpty(itemRegisterRequest.plans)}">
-                <!-- 기존 정적 row 그대로 유지 -->
-              </th:block>
-            </div>
-            <!-- 패키지 추가 버튼 -->
-            <div class="px-4 py-3 border-t border-[#CCC]">
-              <button type="button" id="btn-add-plan"
-                      class="w-full py-2.5 bg-white border-[1.5px] border-dashed border-[#CCC] rounded-xl text-[13px] font-semibold text-[#888] flex items-center justify-center gap-1.5 hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-                패키지 추가
-              </button>
-            </div>
+
+                <!-- 패키지명 -->
+                <input type="text"
+                       th:name="'plans[' + ${stat.index} + '].planName'"
+                       th:value="${itemRegisterRequest.plans != null and itemRegisterRequest.plans.size() > stat.index} ? ${itemRegisterRequest.plans[stat.index].planName} : ''"
+                       placeholder="패키지명"
+                       class="plan-field w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-2.5 py-1.5 text-[13px] text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+
+                <!-- 촬영 시간 -->
+                <div class="flex items-center justify-center gap-1">
+                  <input type="number"
+                         th:name="'plans[' + ${stat.index} + '].shootingDuration'"
+                         th:value="${itemRegisterRequest.plans != null and itemRegisterRequest.plans.size() > stat.index} ? ${itemRegisterRequest.plans[stat.index].shootingDuration} : 2"
+                         min="1" max="12"
+                         class="plan-field w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+                  <span class="text-xs text-[#888] flex-shrink-0">시간</span>
+                </div>
+
+                <!-- 원본 컷 -->
+                <div class="flex items-center justify-center gap-1">
+                  <input type="number"
+                         th:name="'plans[' + ${stat.index} + '].originalPhotoCount'"
+                         th:value="${itemRegisterRequest.plans != null and itemRegisterRequest.plans.size() > stat.index} ? ${itemRegisterRequest.plans[stat.index].originalPhotoCount} : 100"
+                         min="0"
+                         class="plan-field w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+                  <span class="text-xs text-[#888] flex-shrink-0">장</span>
+                </div>
+
+                <!-- 보정 컷 -->
+                <div class="flex items-center justify-center gap-1">
+                  <input type="number"
+                         th:name="'plans[' + ${stat.index} + '].editedPhotoCount'"
+                         th:value="${itemRegisterRequest.plans != null and itemRegisterRequest.plans.size() > stat.index} ? ${itemRegisterRequest.plans[stat.index].editedPhotoCount} : 20"
+                         min="0"
+                         class="plan-field w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+                  <span class="text-xs text-[#888] flex-shrink-0">장</span>
+                </div>
+
+                <!-- 납품 기간 -->
+                <div class="flex items-center justify-center gap-1">
+                  <input type="number"
+                         th:name="'plans[' + ${stat.index} + '].deliveryDays'"
+                         th:value="${itemRegisterRequest.plans != null and itemRegisterRequest.plans.size() > stat.index} ? ${itemRegisterRequest.plans[stat.index].deliveryDays} : 3"
+                         min="1"
+                         class="plan-field w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+                  <span class="text-xs text-[#888] flex-shrink-0">일</span>
+                </div>
+
+                <!-- 가격 -->
+                <div class="relative flex items-center">
+                  <input type="number"
+                         th:name="'plans[' + ${stat.index} + '].price'"
+                         th:value="${itemRegisterRequest.plans != null and itemRegisterRequest.plans.size() > stat.index} ? ${itemRegisterRequest.plans[stat.index].price} : ''"
+                         placeholder="0" min="0"
+                         class="plan-field plan-price w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-2.5 pr-7 py-1.5 text-[13px] text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] transition-colors disabled:opacity-40 disabled:cursor-not-allowed">
+                  <span class="absolute right-2.5 text-xs text-[#888] pointer-events-none">원</span>
+                </div>
+              </div>
+            </th:block>
           </div>
 
           <!-- 최저가 안내 배너 -->
@@ -321,11 +345,28 @@
           <div class="flex flex-col gap-1.5">
             <label class="text-[13px] font-bold text-[#1A1A1A]">기준 지점 (출발지)</label>
             <p class="text-xs text-[#888]">방문 촬영 시 이동 거리 계산의 기준이 됩니다</p>
-            <input type="text" name="address" th:value="${itemRegisterRequest.address}"
-                   placeholder="예: 서울 마포구 합정동"
-                   class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-[10px] px-3.5 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] focus:ring-[3px] focus:ring-[#1D3CFF]/[0.08] transition-all">
-            <input type="hidden" name="lat" value="0.0">
-            <input type="hidden" name="lng" value="0.0">
+            <input type="hidden" id="h-region" name="address" th:value="${itemRegisterRequest.address}">
+            <input type="hidden" id="h-lat"    name="lat"     th:value="${itemRegisterRequest.lat}">
+            <input type="hidden" id="h-lng"    name="lng"     th:value="${itemRegisterRequest.lng}">
+
+            <div class="flex items-center gap-2">
+              <div class="flex-1 bg-[#F9FAFC] border border-[#CCC] rounded-[10px] px-3.5 py-2.5 text-sm min-h-[42px] flex items-center">
+                <span id="display-region"
+                      th:classappend="${itemRegisterRequest.address != null and !#strings.isEmpty(itemRegisterRequest.address)} ? ' text-[#1A1A1A]' : ' text-[#AAA]'"
+                      th:text="${itemRegisterRequest.address != null and !#strings.isEmpty(itemRegisterRequest.address)} ? ${itemRegisterRequest.address} : '지도에서 위치를 선택해주세요'">
+                </span>
+              </div>
+              <button type="button" id="btn-open-location-modal"
+                      class="flex-shrink-0 text-sm font-semibold border border-[#1D3CFF] text-[#1D3CFF] bg-white rounded-[10px] px-4 py-2.5 hover:bg-[#1D3CFF] hover:text-white transition-colors">
+                지도 선택
+              </button>
+              <button type="button" id="clear-region-btn"
+                      th:classappend="${itemRegisterRequest.address == null or #strings.isEmpty(itemRegisterRequest.address)} ? ' hidden' : ''"
+                      onclick="clearRegion()"
+                      class="flex-shrink-0 text-sm font-semibold border border-[#CCC] text-[#888] bg-white rounded-[10px] px-4 py-2.5 hover:border-red-300 hover:text-red-400 transition-colors">
+                초기화
+              </button>
+            </div>
           </div>
 
           <!-- 추가 옵션 -->
@@ -418,6 +459,17 @@
         </div>
 
         <script>
+            function clearRegion() {
+                document.getElementById('h-region').value = '';
+                document.getElementById('h-lat').value = '';
+                document.getElementById('h-lng').value = '';
+                const displayEl = document.getElementById('display-region');
+                displayEl.textContent = '지도에서 위치를 선택해주세요';
+                displayEl.classList.remove('text-[#1A1A1A]');
+                displayEl.classList.add('text-[#AAA]');
+                document.getElementById('clear-region-btn').classList.add('hidden');
+            }
+
             (function () {
                 const MAX = 5;
                 const input = document.getElementById('item-img-input');
@@ -556,11 +608,26 @@
                 });
 
                 render();
+
+                document.getElementById('service-form').addEventListener('submit', function() {
+                    syncInputs();
+                });
             })();
 
-           document.getElementById('service-form').addEventListener('submit', function() {
-               syncInputs();
-           });
+            document.querySelectorAll('.plan-toggle').forEach(toggle => {
+                const row = toggle.closest('.plan-row');
+                const fields = row.querySelectorAll('.plan-field');
+
+                function syncDisabled() {
+                    fields.forEach(f => f.disabled = !toggle.checked);
+                }
+
+                toggle.addEventListener('change', () => {
+                    syncDisabled();
+                    updatePreview();
+                });
+                syncDisabled();
+            });
         </script>
         <script th:if="${itemImgList != null and !itemImgList.isEmpty()}"
                 th:inline="javascript">
@@ -712,87 +779,6 @@
       initialCheckedType.dispatchEvent(new Event('change'));
   }
 
-  /* ─── 패키지 추가/삭제 ─── */
-  let planIndex = 1;
-
-  function createPlanRow(idx) {
-    const row = document.createElement('div');
-    row.className = 'plan-row grid grid-cols-[2fr_1fr_1fr_1fr_1fr_1.5fr_36px] items-center px-4 py-3.5 border-b border-[#CCC] last:border-b-0 gap-2';
-    row.innerHTML = `
-      <div class="flex items-center gap-2">
-        <span class="text-base leading-none flex-shrink-0">📸</span>
-        <input type="text" name="plans[${idx}].planName" placeholder="패키지명"
-               class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-2.5 py-1.5 text-[13px] text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] transition-colors">
-      </div>
-      <div class="flex items-center justify-center gap-1">
-        <input type="number" name="plans[${idx}].shootingDuration" value="2" min="1" max="12"
-               class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
-        <span class="text-xs text-[#888] flex-shrink-0">시간</span>
-      </div>
-      <div class="flex items-center justify-center gap-1">
-        <input type="number" name="plans[${idx}].originalPhotoCount" value="100" min="0"
-               class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
-        <span class="text-xs text-[#888] flex-shrink-0">장</span>
-      </div>
-      <div class="flex items-center justify-center gap-1">
-        <input type="number" name="plans[${idx}].editedPhotoCount" value="20" min="0"
-               class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
-        <span class="text-xs text-[#888] flex-shrink-0">장</span>
-      </div>
-      <div class="flex items-center justify-center gap-1">
-        <input type="number" name="plans[${idx}].deliveryDays" value="3" min="1"
-               class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
-        <span class="text-xs text-[#888] flex-shrink-0">일</span>
-      </div>
-      <div class="relative flex items-center">
-        <input type="number" name="plans[${idx}].price" placeholder="0" min="0"
-               class="plan-price w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-2.5 pr-7 py-1.5 text-[13px] text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] transition-colors">
-        <span class="absolute right-2.5 text-xs text-[#888] pointer-events-none">원</span>
-      </div>
-      <div class="flex items-center justify-center">
-        <button type="button" class="btn-remove-plan w-7 h-7 bg-white border border-[#CCC] rounded-lg flex items-center justify-center text-[#888] hover:border-[#FF4D4D] hover:text-[#FF4D4D] transition-colors flex-shrink-0"
-                onclick="removePlan(this)">
-          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-        </button>
-      </div>`;
-    row.querySelector('.plan-price').addEventListener('input', updatePreview);
-    return row;
-  }
-
-  function reindexPlans() {
-    document.querySelectorAll('#plan-list .plan-row').forEach((row, idx) => {
-      row.querySelectorAll('input').forEach(input => {
-        if (input.name) {
-          input.name = input.name.replace(/plans\[\d+\]/, `plans[${idx}]`);
-        }
-      });
-    });
-    updateRemoveButtons();
-  }
-
-  function removePlan(btn) {
-    const rows = document.querySelectorAll('#plan-list .plan-row');
-    if (rows.length <= 1) return;
-    btn.closest('.plan-row').remove();
-    reindexPlans();
-    updatePreview();
-  }
-
-  function updateRemoveButtons() {
-    const rows = document.querySelectorAll('#plan-list .plan-row');
-    rows.forEach(row => {
-      const btn = row.querySelector('.btn-remove-plan');
-      if (rows.length > 1) btn.classList.remove('invisible');
-      else btn.classList.add('invisible');
-    });
-  }
-
-  document.getElementById('btn-add-plan').addEventListener('click', () => {
-    const row = createPlanRow(planIndex++);
-    document.getElementById('plan-list').appendChild(row);
-    reindexPlans();
-  });
-
   /* ─── 추가 옵션 추가/삭제 ─── */
   document.getElementById('btn-add-option').addEventListener('click', () => {
     const item = document.createElement('div');
@@ -893,7 +879,7 @@
     }
     if (step === 2) {
       const hasPrice = Array.from(document.querySelectorAll('.plan-price')).some(i => parseInt(i.value) > 0);
-      const hasAddress = (document.querySelector('input[name="address"]').value || '').trim().length > 0;
+      const hasAddress = (document.getElementById('h-region').value || '').trim().length > 0;
       return hasPrice && hasAddress;
     }
     if (step === 3) {
@@ -994,12 +980,21 @@
   });
   document.getElementById('desc-textarea').addEventListener('input', updateProgressSidebar);
   document.querySelectorAll('.plan-price').forEach(i => i.addEventListener('input', updateProgressSidebar));
-  document.querySelector('input[name="address"]').addEventListener('input', updateProgressSidebar);
   document.getElementById('lead-time').addEventListener('input', updateProgressSidebar);
   document.querySelector('textarea[name="cancellationPolicy"]').addEventListener('input', updateProgressSidebar);
 
   setActiveStep(1);
+
+  document.getElementById('btn-open-location-modal')
+      .addEventListener('click', () => locationModal.open());
 </script>
 
+<th:block th:replace="~{fragments/modal/location-modal-for-item :: locationModal(
+                  'h-region',
+                  'h-lat',
+                  'h-lng',
+                  'display-region',
+                  'clear-region-btn'
+              )}"/>
 </body>
 </html>

--- a/src/main/resources/templates/photographer/service-register.html
+++ b/src/main/resources/templates/photographer/service-register.html
@@ -29,7 +29,8 @@
       <span class="font-angelica text-[22px] text-[#1D3CFF] tracking-wide">PICKASSO</span>
     </a>
     <div class="flex items-center gap-3">
-      <span class="text-[15px] font-semibold text-[#444]">서비스 등록</span>
+    <span class="text-[15px] font-semibold text-[#444]"
+          th:text="${itemRegisterRequest.name == null} ? '서비스 등록' : '서비스 수정'">서비스 등록</span>
       <button type="button"
               class="flex items-center gap-1.5 text-sm font-semibold text-[#444] bg-white border border-[#CCC] rounded-lg px-4 py-2 hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -144,8 +145,9 @@
       <span th:text="${errorMessage}"></span>
     </div>
 
-    <form th:action="@{/photographer/{id}/service/new(id=${photographerId})}"
+    <form th:action="${formAction}"
           method="post" id="service-form"
+          enctype="multipart/form-data"
           class="flex flex-col gap-5">
 
       <!-- ①── 서비스 기본 정보 ──────────────────── -->
@@ -170,7 +172,8 @@
             <div class="grid grid-cols-4 gap-2.5" id="category-grid">
               <th:block th:each="tag : ${tagList}">
                 <label class="category-option relative flex flex-col items-center justify-center gap-2 py-4 px-2.5 bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-xl cursor-pointer text-[13px] font-medium text-[#444] text-center leading-snug transition-all hover:border-[#1D3CFF] hover:bg-[#EEF1FF]">
-                  <input type="radio" name="tagName" th:value="${tag.name}" class="absolute opacity-0 w-0 h-0">
+                  <input type="radio" name="tagName" th:value="${tag.name}" class="absolute opacity-0 w-0 h-0"
+                         th:checked="${itemRegisterRequest.tagName == tag.name}">
                   <span class="cat-emoji text-2xl" th:text="${tag.emoji ?: '📷'}">📷</span>
                   <span th:text="${tag.name}">카테고리</span>
                 </label>
@@ -184,7 +187,8 @@
               촬영 방식            </label>
             <div class="flex gap-3">
               <label class="shoot-type-option flex-1 relative flex items-center gap-3.5 px-5 py-4 bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-xl cursor-pointer transition-all hover:border-[#1D3CFF]">
-                <input type="radio" name="itemType" value="OUT" class="absolute opacity-0 w-0 h-0" checked>
+                <input type="radio" name="itemType" value="OUT" class="absolute opacity-0 w-0 h-0"
+                       th:checked="${itemRegisterRequest.itemType == null or itemRegisterRequest.itemType.name() == 'OUT'}">
                 <div class="w-10 h-10 rounded-[10px] bg-[#D3DEF2] flex items-center justify-center text-xl flex-shrink-0">📍</div>
                 <div>
                   <div class="text-sm font-bold text-[#1A1A1A]">방문 촬영</div>
@@ -192,7 +196,8 @@
                 </div>
               </label>
               <label class="shoot-type-option flex-1 relative flex items-center gap-3.5 px-5 py-4 bg-[#F9FAFC] border-[1.5px] border-[#CCC] rounded-xl cursor-pointer transition-all hover:border-[#1D3CFF]">
-                <input type="radio" name="itemType" value="IN" class="absolute opacity-0 w-0 h-0">
+                <input type="radio" name="itemType" value="IN" class="absolute opacity-0 w-0 h-0"
+                       th:checked="${itemRegisterRequest.itemType != null and itemRegisterRequest.itemType.name() == 'IN'}">
                 <div class="w-10 h-10 rounded-[10px] bg-[#D3DEF2] flex items-center justify-center text-xl flex-shrink-0">🏢</div>
                 <div>
                   <div class="text-sm font-bold text-[#1A1A1A]">스튜디오 촬영</div>
@@ -207,6 +212,7 @@
             <label for="service-name" class="text-[13px] font-bold text-[#1A1A1A] flex items-center gap-1">
               서비스명            </label>
             <input id="service-name" type="text" name="name" maxlength="60"
+                   th:value="${itemRegisterRequest.name}"
                    placeholder="예: 감성 데이트 스냅 2시간 패키지"
                    class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-[10px] px-3.5 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] focus:ring-[3px] focus:ring-[#1D3CFF]/[0.08] transition-all">
           </div>
@@ -243,45 +249,57 @@
             </div>
             <!-- 패키지 행 목록 -->
             <div id="plan-list">
-              <!-- Plan Row Template (index 0) -->
-              <div class="plan-row grid grid-cols-[2fr_1fr_1fr_1fr_1fr_1.5fr_36px] items-center px-4 py-3.5 border-b border-[#CCC] last:border-b-0 gap-2">
-                <div class="flex items-center gap-2">
-                  <span class="text-base leading-none flex-shrink-0">📸</span>
-                  <input type="text" name="plans[0].planName" value="기본 패키지"
-                         placeholder="패키지명"
-                         class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-2.5 py-1.5 text-[13px] text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] transition-colors">
+              <th:block th:if="${not #lists.isEmpty(itemRegisterRequest.plans)}"
+                        th:each="plan, stat : ${itemRegisterRequest.plans}">
+                <div class="plan-row grid grid-cols-[2fr_1fr_1fr_1fr_1fr_1.5fr_36px] items-center px-4 py-3.5 border-b border-[#CCC] last:border-b-0 gap-2">
+                  <div class="flex items-center gap-2">
+                    <span class="text-base leading-none flex-shrink-0">📸</span>
+                    <input type="text" th:name="'plans[' + ${stat.index} + '].planName'"
+                           th:value="${plan.planName}" placeholder="패키지명"
+                           class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-2.5 py-1.5 text-[13px] text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] transition-colors">
+                  </div>
+                  <div class="flex items-center justify-center gap-1">
+                    <input type="number" th:name="'plans[' + ${stat.index} + '].shootingDuration'"
+                           th:value="${plan.shootingDuration}" min="1" max="12"
+                           class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
+                    <span class="text-xs text-[#888] flex-shrink-0">시간</span>
+                  </div>
+                  <div class="flex items-center justify-center gap-1">
+                    <input type="number" th:name="'plans[' + ${stat.index} + '].originalPhotoCount'"
+                           th:value="${plan.originalPhotoCount}" min="0"
+                           class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
+                    <span class="text-xs text-[#888] flex-shrink-0">장</span>
+                  </div>
+                  <div class="flex items-center justify-center gap-1">
+                    <input type="number" th:name="'plans[' + ${stat.index} + '].editedPhotoCount'"
+                           th:value="${plan.editedPhotoCount}" min="0"
+                           class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
+                    <span class="text-xs text-[#888] flex-shrink-0">장</span>
+                  </div>
+                  <div class="flex items-center justify-center gap-1">
+                    <input type="number" th:name="'plans[' + ${stat.index} + '].deliveryDays'"
+                           th:value="${plan.deliveryDays}" min="1"
+                           class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
+                    <span class="text-xs text-[#888] flex-shrink-0">일</span>
+                  </div>
+                  <div class="relative flex items-center">
+                    <input type="number" th:name="'plans[' + ${stat.index} + '].price'"
+                           th:value="${plan.price}" placeholder="0" min="0"
+                           class="plan-price w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-2.5 pr-7 py-1.5 text-[13px] text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] transition-colors">
+                    <span class="absolute right-2.5 text-xs text-[#888] pointer-events-none">원</span>
+                  </div>
+                  <div class="flex items-center justify-center">
+                    <button type="button" class="btn-remove-plan w-7 h-7 bg-white border border-[#CCC] rounded-lg flex items-center justify-center text-[#888] hover:border-[#FF4D4D] hover:text-[#FF4D4D] transition-colors flex-shrink-0 invisible"
+                            onclick="removePlan(this)">
+                      <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+                    </button>
+                  </div>
                 </div>
-                <div class="flex items-center justify-center gap-1">
-                  <input type="number" name="plans[0].shootingDuration" value="2" min="1" max="12"
-                         class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
-                  <span class="text-xs text-[#888] flex-shrink-0">시간</span>
-                </div>
-                <div class="flex items-center justify-center gap-1">
-                  <input type="number" name="plans[0].originalPhotoCount" value="100" min="0"
-                         class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
-                  <span class="text-xs text-[#888] flex-shrink-0">장</span>
-                </div>
-                <div class="flex items-center justify-center gap-1">
-                  <input type="number" name="plans[0].editedPhotoCount" value="20" min="0"
-                         class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
-                  <span class="text-xs text-[#888] flex-shrink-0">장</span>
-                </div>
-                <div class="flex items-center justify-center gap-1">
-                  <input type="number" name="plans[0].deliveryDays" value="3" min="1"
-                         class="w-14 text-center bg-[#F9FAFC] border border-[#CCC] rounded-lg px-1.5 py-1.5 text-[13px] text-[#1A1A1A] outline-none focus:border-[#1D3CFF] transition-colors">
-                  <span class="text-xs text-[#888] flex-shrink-0">일</span>
-                </div>
-                <div class="relative flex items-center">
-                  <input type="number" name="plans[0].price" placeholder="0" min="0"
-                         class="plan-price w-full bg-[#F9FAFC] border border-[#CCC] rounded-lg px-2.5 pr-7 py-1.5 text-[13px] text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] transition-colors">
-                  <span class="absolute right-2.5 text-xs text-[#888] pointer-events-none">원</span>
-                </div>
-                <div class="flex items-center justify-center">
-                  <button type="button" class="btn-remove-plan w-7 h-7 bg-white border border-[#CCC] rounded-lg flex items-center justify-center text-[#888] hover:border-[#FF4D4D] hover:text-[#FF4D4D] transition-colors flex-shrink-0 invisible">
-                    <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
-                  </button>
-                </div>
-              </div>
+              </th:block>
+              <!-- plans가 비어있을 때 기본 row -->
+              <th:block th:if="${#lists.isEmpty(itemRegisterRequest.plans)}">
+                <!-- 기존 정적 row 그대로 유지 -->
+              </th:block>
             </div>
             <!-- 패키지 추가 버튼 -->
             <div class="px-4 py-3 border-t border-[#CCC]">
@@ -303,7 +321,8 @@
           <div class="flex flex-col gap-1.5">
             <label class="text-[13px] font-bold text-[#1A1A1A]">기준 지점 (출발지)</label>
             <p class="text-xs text-[#888]">방문 촬영 시 이동 거리 계산의 기준이 됩니다</p>
-            <input type="text" name="address" placeholder="예: 서울 마포구 합정동"
+            <input type="text" name="address" th:value="${itemRegisterRequest.address}"
+                   placeholder="예: 서울 마포구 합정동"
                    class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-[10px] px-3.5 py-2.5 text-sm text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] focus:ring-[3px] focus:ring-[#1D3CFF]/[0.08] transition-all">
             <input type="hidden" name="lat" value="0.0">
             <input type="hidden" name="lng" value="0.0">
@@ -363,7 +382,7 @@
           <div class="flex flex-col gap-1.5">
             <label class="text-[13px] font-bold text-[#1A1A1A] flex items-center gap-1">
               서비스 소개            </label>
-            <textarea name="description" rows="6" maxlength="1000"
+            <textarea name="description" th:text="${itemRegisterRequest.description}" rows="6" maxlength="1000"
                       placeholder="이 서비스가 어떤 고객에게 적합한지, 촬영 과정은 어떻게 진행되는지 자세히 설명해 주세요."
                       class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-[10px] px-3.5 py-3 text-sm text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] focus:ring-[3px] focus:ring-[#1D3CFF]/[0.08] resize-y leading-7 transition-all"
                       id="desc-textarea"></textarea>
@@ -391,24 +410,162 @@
           <span>첫 번째 이미지가 검색 목록의 대표 썸네일로 사용됩니다. JPG, PNG, WebP · 이미지당 최대 10MB · 최대 5장</span>
         </div>
 
-        <div class="grid grid-cols-4 gap-3">
-          <!-- 첫 번째 = 대표 이미지 -->
-          <div class="aspect-[4/3] rounded-xl border-2 border-dashed border-[#1D3CFF] bg-[#EEF1FF] flex flex-col items-center justify-center gap-1.5 cursor-pointer hover:bg-[#dce3ff] transition-all" id="main-thumb-slot">
-            <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#1D3CFF" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
-            <span class="text-xs font-semibold text-[#1D3CFF]">대표 이미지</span>
-            <span class="text-[10px] text-[#888]">첫 번째 = 썸네일</span>
-          </div>
-          <!-- 나머지 3장 -->
-          <div class="aspect-[4/3] rounded-xl border-2 border-dashed border-[#CCC] flex flex-col items-center justify-center gap-1 cursor-pointer hover:border-[#1D3CFF] hover:bg-[#EEF1FF] transition-all text-[11px] text-[#AAA] font-medium">
-            <span class="text-xl text-[#CCC]">＋</span>추가
-          </div>
-          <div class="aspect-[4/3] rounded-xl border-2 border-dashed border-[#CCC] flex flex-col items-center justify-center gap-1 cursor-pointer hover:border-[#1D3CFF] hover:bg-[#EEF1FF] transition-all text-[11px] text-[#AAA] font-medium">
-            <span class="text-xl text-[#CCC]">＋</span>추가
-          </div>
-          <div class="aspect-[4/3] rounded-xl border-2 border-dashed border-[#CCC] flex flex-col items-center justify-center gap-1 cursor-pointer hover:border-[#1D3CFF] hover:bg-[#EEF1FF] transition-all text-[11px] text-[#AAA] font-medium">
-            <span class="text-xl text-[#CCC]">＋</span>추가
-          </div>
+        <!-- 숨김 file input -->
+        <input type="file" id="item-img-input" multiple accept="image/jpeg,image/png,image/webp" class="hidden">
+
+        <div class="grid grid-cols-4 gap-3" id="img-slots">
+          <!-- 슬롯 0 ~ 3 은 JS로 렌더링 -->
         </div>
+
+        <script>
+            (function () {
+                const MAX = 5;
+                const input = document.getElementById('item-img-input');
+                const slotsEl = document.getElementById('img-slots');
+                let dragSrcIdx = null;
+
+                // {type: 'kept', url, order} | {type: 'new', file, url, order}
+                let items = [];
+
+                // 수정 시 기존 이미지 초기화 (Thymeleaf로 주입)
+                // items = [ {type:'kept', url:'https://...', order:0}, ... ]
+
+                function render() {
+                    slotsEl.innerHTML = '';
+
+                    items.forEach((item, idx) => {
+                        const div = document.createElement('div');
+                        div.className = 'relative aspect-[4/3] rounded-xl overflow-hidden border-2 border-[#1D3CFF] bg-[#EEF1FF] cursor-grab';
+                        div.draggable = true;
+                        div.dataset.idx = idx;
+                        div.innerHTML = `
+        <img src="${item.url}" class="w-full h-full object-cover pointer-events-none">
+        ${idx === 0 ? '<span class="absolute top-1.5 left-1.5 text-[10px] font-bold bg-[#1D3CFF] text-white px-2 py-0.5 rounded-full">대표</span>' : ''}
+        <button type="button" onclick="removeImg(${idx})"
+                class="absolute top-1.5 right-1.5 w-5 h-5 rounded-full bg-black/50 text-white text-xs flex items-center justify-center hover:bg-black/80">✕</button>
+      `;
+
+                        div.addEventListener('dragstart', e => {
+                            dragSrcIdx = idx;
+                            e.dataTransfer.effectAllowed = 'move';
+                            setTimeout(() => div.classList.add('opacity-40'), 0);
+                        });
+                        div.addEventListener('dragend', () => {
+                            div.classList.remove('opacity-40');
+                            document.querySelectorAll('.drag-over').forEach(el => el.classList.remove('drag-over', 'scale-105'));
+                        });
+                        div.addEventListener('dragover', e => {
+                            e.preventDefault();
+                            div.classList.add('drag-over', 'scale-105');
+                        });
+                        div.addEventListener('dragleave', () => {
+                            div.classList.remove('drag-over', 'scale-105');
+                        });
+                        div.addEventListener('drop', e => {
+                            e.preventDefault();
+                            div.classList.remove('drag-over', 'scale-105');
+                            if (dragSrcIdx === null || dragSrcIdx === idx) return;
+                            const moved = items.splice(dragSrcIdx, 1)[0];
+                            items.splice(idx, 0, moved);
+                            dragSrcIdx = null;
+                            render();
+                        });
+
+                        slotsEl.appendChild(div);
+                    });
+
+                    // 빈 슬롯
+                    const emptyCount = Math.min(4, MAX - items.length);
+                    for (let i = 0; i < emptyCount; i++) {
+                        const div = document.createElement('div');
+                        const isFirst = items.length === 0 && i === 0;
+                        div.className = `aspect-[4/3] rounded-xl border-2 border-dashed ${isFirst ? 'border-[#1D3CFF] bg-[#EEF1FF]' : 'border-[#CCC]'} flex flex-col items-center justify-center gap-1.5 cursor-pointer hover:border-[#1D3CFF] hover:bg-[#EEF1FF] transition-all`;
+                        div.innerHTML = isFirst
+                            ? `<svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="#1D3CFF" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+           <span class="text-xs font-semibold text-[#1D3CFF]">대표 이미지</span>
+           <span class="text-[10px] text-[#888]">첫 번째 = 썸네일</span>`
+                            : `<span class="text-xl text-[#CCC]">＋</span><span class="text-[11px] text-[#AAA] font-medium">추가</span>`;
+                        div.addEventListener('click', () => input.click());
+                        slotsEl.appendChild(div);
+                    }
+
+                    syncInputs();
+                }
+                function syncInputs() {
+                    // 기존 hidden input 및 동적 file input 제거
+                    document.querySelectorAll('#service-form .img-hidden-input').forEach(el => el.remove());
+
+                    const keptItems = items.filter(i => i.type === 'kept');
+                    const newItems  = items.filter(i => i.type === 'new');
+
+                    // keptImgUrls, keptImgOrders
+                    keptItems.forEach(item => {
+                        appendHidden('keptImgUrls', item.url);
+                        appendHidden('keptImgOrders', items.indexOf(item));
+                    });
+
+                    // newFileOrders
+                    newItems.forEach(item => {
+                        appendHidden('newFileOrders', items.indexOf(item));
+                    });
+
+                    // 신규 파일 → DataTransfer로 file input 동적 생성
+                    const dt = new DataTransfer();
+                    newItems.forEach(item => dt.items.add(item.file));
+
+                    if (dt.files.length > 0) {
+                        const fileInput = document.createElement('input');
+                        fileInput.type = 'file';
+                        fileInput.name = 'newFiles';
+                        fileInput.style.display = 'none';
+                        fileInput.className = 'img-hidden-input';
+                        fileInput.files = dt.files;
+                        document.getElementById('service-form').appendChild(fileInput);
+                    }
+                }
+
+                function appendHidden(name, value) {
+                    const el = document.createElement('input');
+                    el.type = 'hidden';
+                    el.name = name;
+                    el.value = value;
+                    el.className = 'img-hidden-input';
+                    document.getElementById('service-form').appendChild(el);
+                }
+
+                window.removeImg = function (idx) {
+                    if (items[idx].type === 'new') URL.revokeObjectURL(items[idx].url);
+                    items.splice(idx, 1);
+                    render();
+                };
+
+                // 수정 시 기존 이미지 주입용 (Thymeleaf 인라인)
+                window.initKeptImages = function (imgList) {
+                    items = imgList
+                        .sort((a, b) => a.imgOrder - b.imgOrder)
+                        .map(img => ({ type: 'kept', url: img.imgUrl, order: img.imgOrder }));
+                    render();
+                };;
+
+                input.addEventListener('change', function () {
+                    Array.from(this.files).forEach(f => {
+                        if (items.length < MAX) items.push({ type: 'new', file: f, url: URL.createObjectURL(f) });
+                    });
+                    this.value = '';
+                    render();
+                });
+
+                render();
+            })();
+
+           document.getElementById('service-form').addEventListener('submit', function() {
+               syncInputs();
+           });
+        </script>
+        <script th:if="${itemImgList != null and !itemImgList.isEmpty()}"
+                th:inline="javascript">
+            window.initKeptImages(/*[[${itemImgList}]]*/ []);
+        </script>
       </div>
 
       <!-- ⑤── 예약 설정 ──────────────────────────── -->
@@ -448,7 +605,9 @@
                 <span class="text-[#888] text-xs">플랫폼 규정에 따라 일부 조건은 수정이 제한될 수 있습니다.</span>
               </div>
             </div>
-            <textarea name="cancellationPolicy" rows="3"
+            <textarea name="cancellationPolicy"
+                      th:text="${itemRegisterRequest.cancellationPolicy}"
+                      rows="3"
                       placeholder="추가 취소/환불 안내 사항이 있으면 작성해 주세요."
                       class="w-full bg-[#F9FAFC] border border-[#CCC] rounded-[10px] px-3.5 py-3 text-sm text-[#1A1A1A] placeholder-[#AAA] outline-none focus:border-[#1D3CFF] focus:ring-[3px] focus:ring-[#1D3CFF]/[0.08] resize-y leading-7 transition-all mt-1"></textarea>
           </div>
@@ -505,7 +664,6 @@
     </div>
   </div>
 </div>
-
 <script>
   /* ─── 카테고리 카드 선택 ─── */
   document.querySelectorAll('.category-option').forEach(label => {
@@ -540,8 +698,19 @@
       updatePreview();
     });
   });
-  // 초기 방문촬영 선택 상태 표시
-  document.querySelector('.shoot-type-option input[value="OUT"]').dispatchEvent(new Event('change'));
+
+  // 카테고리 초기 선택 UI 반영
+  const initialCheckedCat = document.querySelector('.category-option input:checked');
+  if (initialCheckedCat) {
+      initialCheckedCat.closest('label').classList.add('bg-[#EEF1FF]', 'border-[#1D3CFF]', 'text-[#1D3CFF]', 'font-bold');
+      initialCheckedCat.closest('label').classList.remove('bg-[#F9FAFC]', 'border-[#CCC]', 'text-[#444]', 'font-medium');
+  }
+
+  // 촬영방식 초기 선택 UI 반영
+  const initialCheckedType = document.querySelector('.shoot-type-option input:checked');
+  if (initialCheckedType) {
+      initialCheckedType.dispatchEvent(new Event('change'));
+  }
 
   /* ─── 패키지 추가/삭제 ─── */
   let planIndex = 1;

--- a/src/test/java/com/pickkasso/pickkasso/user/service/PhotographerProfileServiceTest.java
+++ b/src/test/java/com/pickkasso/pickkasso/user/service/PhotographerProfileServiceTest.java
@@ -4,12 +4,7 @@ import com.pickkasso.pickkasso.user.dto.photographer.CareerDto;
 import com.pickkasso.pickkasso.user.dto.photographer.EducationDto;
 import com.pickkasso.pickkasso.user.dto.photographer.PhotographerProfileEditRequest;
 import com.pickkasso.pickkasso.user.dto.photographer.PhotographerProfileResponse;
-import com.pickkasso.pickkasso.user.entity.Account;
-import com.pickkasso.pickkasso.user.entity.Career;
-import com.pickkasso.pickkasso.user.entity.Education;
-import com.pickkasso.pickkasso.user.entity.Gender;
-import com.pickkasso.pickkasso.user.entity.Photographer;
-import com.pickkasso.pickkasso.user.entity.Role;
+import com.pickkasso.pickkasso.user.entity.*;
 import com.pickkasso.pickkasso.user.repository.AccountRepository;
 import com.pickkasso.pickkasso.user.repository.CareerRepository;
 import com.pickkasso.pickkasso.user.repository.EducationRepository;
@@ -55,6 +50,9 @@ class PhotographerProfileServiceTest {
                 "김민준 작가",
                 "안녕하세요. 감성 스냅 작가입니다.",
                 "https://example.com",
+                0,
+                0,
+                ResponseTime.IN_DAY,
                 List.of("Sony A7IV", "85mm f1.4"),
                 List.of(
                         new CareerDto(null, "프리랜서 사진작가", LocalDate.of(2020, 1, 1), null)
@@ -92,6 +90,9 @@ class PhotographerProfileServiceTest {
                 "기존 작가명",
                 "기존 소개",
                 "https://first.com",
+                0,
+                0,
+                ResponseTime.IN_DAY,
                 List.of("기존 장비"),
                 List.of(),
                 List.of()
@@ -104,6 +105,9 @@ class PhotographerProfileServiceTest {
                 "수정된 작가명",
                 "수정된 소개",
                 "https://updated.com",
+                0,
+                0,
+                ResponseTime.IN_DAY,
                 List.of("Sony A7IV", "35mm"),
                 List.of(
                         new CareerDto(null, "수정 경력", LocalDate.of(2021, 1, 1), null)


### PR DESCRIPTION
## 작업 내용
- emoji 분리 -> tag에 emoji를 추가하여, 다른 페이지에서도 원활하게 사용가능하도록 변경
- Plan을 custom해서 추가하는 방식 -> 고정된 3종류의 Plan을 사용하는 방식으로 변경
- Item 구조 변경
- 지역 선택이 지도를 통해 이루어지게 변경
- 필요한 페이지에 이미지 삽입

## 변경 사항
- Tag Entity 및 t_tag table 변경 (emoji column 추가)
- Plan Entity 및 t_plan table 변경 (plan_type, enabled column 추가)
- Item Entity 및 t_item table 변경 (thumbnail_img_url column 추가)

## 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 관련 페이지 렌더링 확인