### PR TITLE
feat: 리뷰 정렬/더보기 구현 및 명세 DTO 매핑 정합성 보완

### DIFF
--- a/src/main/java/com/pickkasso/pickkasso/item/controller/ItemController.java
+++ b/src/main/java/com/pickkasso/pickkasso/item/controller/ItemController.java
@@ -12,8 +12,11 @@ import com.pickkasso.pickkasso.review.dto.ReviewDto;
 import com.pickkasso.pickkasso.review.repository.ReviewRepository;
 import com.pickkasso.pickkasso.user.service.PhotographerProfileService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -33,6 +36,7 @@ public class ItemController {
     private final PlanService planService;
     private final ReviewRepository reviewRepository;
     private static final int PAGE_VIEW_COUNT = 20;
+    private static final int REVIEW_PAGE_SIZE = 5;
 
     private ItemSearchCondition toCondition(ItemSearchFormDto dto) {
         ItemSearchCondition condition = new ItemSearchCondition();
@@ -96,9 +100,19 @@ public class ItemController {
         model.addAttribute("itemImgList", itemService.getItemImage(photographerId, id));
         model.addAttribute("canEditService", isOwnerPhotographer(item, authentication));
 
-        List<ReviewDto> reviews = reviewRepository.findByItemIdWithDetails(id)
-                .stream().map(ReviewDto::new).toList();
+        Pageable reviewPageable = PageRequest.of(0, REVIEW_PAGE_SIZE, Sort.by(Sort.Order.desc("createdAt")));
+        List<ReviewDto> reviews = reviewRepository.findByReservation_Item_Id(id, reviewPageable)
+            .map(ReviewDto::new)
+            .getContent();
+        List<ReviewDto> allReviews = reviewRepository.findByItemIdWithDetails(id)
+            .stream().map(ReviewDto::new).toList();
+        int reviewCount = allReviews.size();
+        double avgRating = allReviews.stream().mapToInt(ReviewDto::getRating).average().orElse(0.0);
         model.addAttribute("reviews", reviews);
+        model.addAttribute("reviewCount", reviewCount);
+        model.addAttribute("reviewHasNext", reviewCount > reviews.size());
+        model.addAttribute("avgRatingValue", avgRating);
+        model.addAttribute("avgRating", String.format("%.1f", avgRating));
 
         return "photographer/service-detail";
     }

--- a/src/main/java/com/pickkasso/pickkasso/review/controller/ReviewController.java
+++ b/src/main/java/com/pickkasso/pickkasso/review/controller/ReviewController.java
@@ -10,6 +10,10 @@ import com.pickkasso.pickkasso.user.repository.AccountRepository;
 import com.pickkasso.pickkasso.user.repository.MemberRepository;
 import com.pickkasso.pickkasso.user.repository.ReservationRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -19,6 +23,7 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 @Controller
 @RequiredArgsConstructor
 public class ReviewController {
+    private static final int FRAGMENT_PAGE_SIZE = 5;
 
     private final ReviewService reviewService;
     private final ReviewRepository reviewRepository;
@@ -61,6 +66,52 @@ public class ReviewController {
             return "redirect:/reservations/" + reservationId + "/review";
         }
         return "redirect:/member/mypage/reservations";
+    }
+
+    @GetMapping("/review/item/{itemId}/fragment")
+    public String itemReviewFragment(
+        @PathVariable Long itemId,
+        @RequestParam(value = "orderBy", defaultValue = "recent") String orderBy,
+        @RequestParam(value = "page", defaultValue = "0") Integer page,
+        Model model
+    ) {
+        Pageable pageable = PageRequest.of(Math.max(page, 0), FRAGMENT_PAGE_SIZE, resolveSort(orderBy));
+        Page<com.pickkasso.pickkasso.review.dto.spec.ReviewDto> reviewPage = reviewRepository
+            .findByReservation_Item_Id(itemId, pageable)
+            .map(com.pickkasso.pickkasso.review.dto.spec.ReviewDto::from);
+
+        model.addAttribute("reviews", reviewPage.getContent());
+        model.addAttribute("reviewCount", (int) reviewPage.getTotalElements());
+        model.addAttribute("hasNext", reviewPage.hasNext());
+        return "review/item_review_fragment :: reviewList";
+    }
+
+    @GetMapping("/review/photographer/{photographerId}/fragment")
+    public String photographerReviewFragment(
+        @PathVariable Long photographerId,
+        @RequestParam(value = "orderBy", defaultValue = "recent") String orderBy,
+        @RequestParam(value = "page", defaultValue = "0") Integer page,
+        Model model
+    ) {
+        Pageable pageable = PageRequest.of(Math.max(page, 0), FRAGMENT_PAGE_SIZE, resolveSort(orderBy));
+        Page<com.pickkasso.pickkasso.review.dto.spec.ReviewDto> reviewPage = reviewRepository
+            .findByPhotographer_Id(photographerId, pageable)
+            .map(com.pickkasso.pickkasso.review.dto.spec.ReviewDto::from);
+
+        model.addAttribute("reviews", reviewPage.getContent());
+        model.addAttribute("reviewCount", (int) reviewPage.getTotalElements());
+        model.addAttribute("hasNext", reviewPage.hasNext());
+        return "review/photographer_review_fragment :: reviewList";
+    }
+
+    private Sort resolveSort(String orderBy) {
+        if ("score-desc".equalsIgnoreCase(orderBy)) {
+            return Sort.by(Sort.Order.desc("rating"), Sort.Order.desc("createdAt"));
+        }
+        if ("score-asc".equalsIgnoreCase(orderBy)) {
+            return Sort.by(Sort.Order.asc("rating"), Sort.Order.desc("createdAt"));
+        }
+        return Sort.by(Sort.Order.desc("createdAt"));
     }
 
     private Member resolveMember(Authentication auth) {

--- a/src/main/java/com/pickkasso/pickkasso/review/dto/spec/MemberSimpleCardDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/review/dto/spec/MemberSimpleCardDto.java
@@ -1,0 +1,21 @@
+package com.pickkasso.pickkasso.review.dto.spec;
+
+import com.pickkasso.pickkasso.user.entity.Member;
+import lombok.Getter;
+
+@Getter
+public class MemberSimpleCardDto {
+    private final Long id;
+    private final String imgUrl;
+    private final String name;
+
+    private MemberSimpleCardDto(Long id, String imgUrl, String name) {
+        this.id = id;
+        this.imgUrl = imgUrl;
+        this.name = name;
+    }
+
+    public static MemberSimpleCardDto from(Member member) {
+        return new MemberSimpleCardDto(member.getId(), null, member.getName());
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/review/dto/spec/OrderDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/review/dto/spec/OrderDto.java
@@ -1,0 +1,75 @@
+package com.pickkasso.pickkasso.review.dto.spec;
+
+import com.pickkasso.pickkasso.global.region.RegionDto;
+import com.pickkasso.pickkasso.item.entity.Plan;
+import com.pickkasso.pickkasso.user.entity.Reservation;
+import com.pickkasso.pickkasso.user.entity.ReservationStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.Map;
+
+@Getter
+public class OrderDto {
+    private final Long itemId;
+    private final MemberSimpleCardDto buyer;
+    private final PhotographerSimpleCardDto photographer;
+    private final RegionDto region;
+    private final PlanDto plan;
+    private final LocalDateTime startDate;
+    private final ReservationStatus orderState;
+    private final Map<String, Object> planField;
+
+    private OrderDto(
+        Long itemId,
+        MemberSimpleCardDto buyer,
+        PhotographerSimpleCardDto photographer,
+        RegionDto region,
+        PlanDto plan,
+        LocalDateTime startDate,
+        ReservationStatus orderState,
+        Map<String, Object> planField
+    ) {
+        this.itemId = itemId;
+        this.buyer = buyer;
+        this.photographer = photographer;
+        this.region = region;
+        this.plan = plan;
+        this.startDate = startDate;
+        this.orderState = orderState;
+        this.planField = planField;
+    }
+
+    public static OrderDto from(Reservation reservation) {
+        PlanDto selectedPlan = reservation.getItem().getPlanList().stream()
+            .filter(plan -> Boolean.TRUE.equals(plan.getEnabled()))
+            .min(Comparator.<Plan>comparingInt(plan -> plan.getPrice() != null ? plan.getPrice() : Integer.MAX_VALUE)
+                .thenComparing(plan -> plan.getId() != null ? plan.getId() : Long.MAX_VALUE))
+            .map(PlanDto::from)
+            .orElseGet(() -> reservation.getItem().getPlanList().stream()
+                .min(Comparator.comparing(plan -> plan.getId() != null ? plan.getId() : Long.MAX_VALUE))
+                .map(PlanDto::from)
+                .orElse(null));
+
+        return new OrderDto(
+            reservation.getItem().getId(),
+            MemberSimpleCardDto.from(reservation.getMember()),
+            PhotographerSimpleCardDto.from(reservation.getPhotographer()),
+            new RegionDto(
+                reservation.getAddress(),
+                reservation.getItem().getDetailAddress(),
+                reservation.getItem().getLat(),
+                reservation.getItem().getLng()
+            ),
+            selectedPlan,
+            reservation.getScheduledAt(),
+            reservation.getStatus(),
+            Map.of(
+                "itemName", reservation.getItem().getName(),
+                "totalPrice", reservation.getTotalPrice(),
+                "durationMinutes", reservation.getDurationMinutes()
+            )
+        );
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/review/dto/spec/PhotographerSimpleCardDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/review/dto/spec/PhotographerSimpleCardDto.java
@@ -1,0 +1,21 @@
+package com.pickkasso.pickkasso.review.dto.spec;
+
+import com.pickkasso.pickkasso.user.entity.Photographer;
+import lombok.Getter;
+
+@Getter
+public class PhotographerSimpleCardDto {
+    private final Long id;
+    private final String imgUrl;
+    private final String name;
+
+    private PhotographerSimpleCardDto(Long id, String imgUrl, String name) {
+        this.id = id;
+        this.imgUrl = imgUrl;
+        this.name = name;
+    }
+
+    public static PhotographerSimpleCardDto from(Photographer photographer) {
+        return new PhotographerSimpleCardDto(photographer.getId(), null, photographer.getName());
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/review/dto/spec/PlanDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/review/dto/spec/PlanDto.java
@@ -1,0 +1,24 @@
+package com.pickkasso.pickkasso.review.dto.spec;
+
+import com.pickkasso.pickkasso.item.entity.Plan;
+import lombok.Getter;
+
+@Getter
+public class PlanDto {
+    private final Long id;
+    private final String name;
+    private final Integer price;
+
+    public PlanDto(Long id, String name, Integer price) {
+        this.id = id;
+        this.name = name;
+        this.price = price;
+    }
+
+    public static PlanDto from(Plan plan) {
+        if (plan == null) {
+            return null;
+        }
+        return new PlanDto(plan.getId(), plan.getName(), plan.getPrice());
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/review/dto/spec/ReviewDto.java
+++ b/src/main/java/com/pickkasso/pickkasso/review/dto/spec/ReviewDto.java
@@ -1,0 +1,25 @@
+package com.pickkasso.pickkasso.review.dto.spec;
+
+import com.pickkasso.pickkasso.review.entity.Review;
+import lombok.Getter;
+
+@Getter
+public class ReviewDto {
+    private final OrderDto order;
+    private final Integer score;
+    private final String description;
+
+    private ReviewDto(OrderDto order, Integer score, String description) {
+        this.order = order;
+        this.score = score;
+        this.description = description;
+    }
+
+    public static ReviewDto from(Review review) {
+        return new ReviewDto(
+            OrderDto.from(review.getReservation()),
+            review.getRating(),
+            review.getContent()
+        );
+    }
+}

--- a/src/main/java/com/pickkasso/pickkasso/review/repository/ReviewRepository.java
+++ b/src/main/java/com/pickkasso/pickkasso/review/repository/ReviewRepository.java
@@ -1,6 +1,9 @@
 package com.pickkasso.pickkasso.review.repository;
 
 import com.pickkasso.pickkasso.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,6 +14,14 @@ import java.util.Optional;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     boolean existsByReservationId(Long reservationId);
     Optional<Review> findByReservationId(Long reservationId);
+    long countByReservation_Item_Id(Long itemId);
+    long countByPhotographer_Id(Long photographerId);
+
+    @EntityGraph(attributePaths = {"member", "photographer", "reservation", "reservation.item"})
+    Page<Review> findByReservation_Item_Id(Long itemId, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"member", "photographer", "reservation", "reservation.item"})
+    Page<Review> findByPhotographer_Id(Long photographerId, Pageable pageable);
 
     @Query("""
             select r from Review r

--- a/src/main/java/com/pickkasso/pickkasso/user/auth/SecurityConfig.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/auth/SecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import org.thymeleaf.extras.springsecurity6.dialect.SpringSecurityDialect;
 
 @Configuration
 @EnableWebSecurity
@@ -24,7 +23,8 @@ public class SecurityConfig {
                     .requestMatchers("/", "/login", "/signup/**", "/find-account", "/403", "/404", "/500", "/400", "/error-default",
                         "/css/**", "/fonts/**", "/js/**", "/images/**",
                         "/find-id/**", "/find-pw/**", "/item/**",
-                        "/search/**", "/items/fragment","/api/check-username"
+                        "/search/**", "/items/fragment","/api/check-username",
+                        "/review/item/**", "/review/photographer/**"
                     ).permitAll()
                     .requestMatchers("/photographer/*/profile", "/photographer/*/portfolio/*").permitAll()
                     .requestMatchers("/photographer/**").hasRole("PHOTOGRAPHER")

--- a/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerDashboardController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerDashboardController.java
@@ -221,6 +221,10 @@ public class PhotographerDashboardController {
         Long photographerId = photographer.getId();
         LocalDate normalizedWeekStart = reservationService.normalizeWeekStart(weekStart);
         ProfileCompletionDto completion = photographerProfileService.getProfileCompletion(photographerId);
+        List<ReviewDto> recentReviews = reviewRepository.findByPhotographerIdWithDetails(photographerId).stream()
+                .limit(2)
+                .map(ReviewDto::new)
+                .toList();
 
         model.addAttribute("photographer", photographer);
         model.addAttribute("userId", photographerId);
@@ -230,5 +234,6 @@ public class PhotographerDashboardController {
         model.addAttribute("pendingList", reservationService.getPendingList(photographerId));
         model.addAttribute("todaySchedule", reservationService.getTodaySchedule(photographerId));
         model.addAttribute("weekly", reservationService.getWeeklyCalendar(photographerId, normalizedWeekStart));
+        model.addAttribute("recentReviews", recentReviews);
     }
 }

--- a/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerProfileController.java
+++ b/src/main/java/com/pickkasso/pickkasso/user/controller/PhotographerProfileController.java
@@ -10,6 +10,9 @@ import com.pickkasso.pickkasso.user.entity.ResponseTime;
 import com.pickkasso.pickkasso.user.repository.AccountRepository;
 import com.pickkasso.pickkasso.user.service.PhotographerProfileService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -27,6 +30,7 @@ public class PhotographerProfileController {
     private final ItemService itemService;
     private final AccountRepository accountRepository;
     private final ReviewRepository reviewRepository;
+    private static final int REVIEW_PAGE_SIZE = 5;
 
     @GetMapping
     public String profilePage(@PathVariable Long photographerId, Model model, Authentication authentication) {
@@ -34,11 +38,16 @@ public class PhotographerProfileController {
         model.addAttribute("profile", response);
         model.addAttribute("items", itemService.getItemBoxDtoById(photographerId));
 
-        List<ReviewDto> reviews = reviewRepository.findByPhotographerIdWithDetails(photographerId)
+        Pageable reviewPageable = PageRequest.of(0, REVIEW_PAGE_SIZE, Sort.by(Sort.Order.desc("createdAt")));
+        List<ReviewDto> reviews = reviewRepository.findByPhotographer_Id(photographerId, reviewPageable)
+                .map(ReviewDto::new)
+                .getContent();
+        List<ReviewDto> allReviews = reviewRepository.findByPhotographerIdWithDetails(photographerId)
                 .stream().map(ReviewDto::new).toList();
-        double avgRating = reviews.stream().mapToInt(ReviewDto::getRating).average().orElse(0.0);
+        double avgRating = allReviews.stream().mapToInt(ReviewDto::getRating).average().orElse(0.0);
         model.addAttribute("reviews", reviews);
-        model.addAttribute("reviewCount", reviews.size());
+        model.addAttribute("reviewCount", allReviews.size());
+        model.addAttribute("reviewHasNext", allReviews.size() > reviews.size());
         model.addAttribute("avgRating", String.format("%.1f", avgRating));
 
         boolean isOwner = false;

--- a/src/main/resources/templates/photographer/dashboard.html
+++ b/src/main/resources/templates/photographer/dashboard.html
@@ -508,40 +508,29 @@
                         <svg class="w-4 h-4 text-[#1D3CFF]" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h4m1 8l-4-4H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-3l-4 4z" /></svg>
                         최근 후기
                     </div>
-                    <a href="#" class="text-[11px] font-bold text-[#0097FF] hover:opacity-70 transition-opacity no-underline">전체 보기 →</a>
+                    <a th:href="@{/photographer/{pid}/reviews(pid=${photographer.id})}"
+                       class="text-[11px] font-bold text-[#0097FF] hover:opacity-70 transition-opacity no-underline">전체 보기 →</a>
                 </div>
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div class="border border-[#EEE] rounded-xl p-4">
+                <div th:if="${recentReviews != null and !#lists.isEmpty(recentReviews)}"
+                     class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div th:each="review : ${recentReviews}" class="border border-[#EEE] rounded-xl p-4">
                         <div class="flex items-center gap-2 mb-2.5">
                             <div class="flex text-[#0097FF]">
-                                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
-                                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
-                                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
-                                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
-                                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
+                                <th:block th:each="i : ${#numbers.sequence(1, 5)}">
+                                    <svg class="w-3.5 h-3.5" th:style="${i <= review.rating} ? 'color:#0097FF' : 'color:#D1D5DB'" fill="currentColor" viewBox="0 0 20 20">
+                                        <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
+                                    </svg>
+                                </th:block>
                             </div>
-                            <span class="text-[11px] font-bold text-[#1A1A1A]">최유진</span>
-                            <span class="text-[11px] text-[#888]">· 2026.04.08</span>
+                            <span class="text-[11px] font-bold text-[#1A1A1A]" th:text="${review.memberName}">고객명</span>
+                            <span class="text-[11px] text-[#888]" th:text="'· ' + ${review.createdAt}">· 2026.04.08</span>
                         </div>
-                        <p class="text-[13px] text-[#444] leading-relaxed line-clamp-2 mb-2">작가님이 너무 친절하시고 사진도 예쁘게 잘 나왔어요! 다음에도 꼭 다시 이용하고 싶습니다. 분위기도 너무 좋았어요.</p>
-                        <div class="text-[11px] font-semibold text-[#1D3CFF]">졸업사진 촬영</div>
-                    </div>
-                    <div class="border border-[#EEE] rounded-xl p-4">
-                        <div class="flex items-center gap-2 mb-2.5">
-                            <div class="flex text-[#0097FF]">
-                                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
-                                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
-                                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
-                                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
-                                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg>
-                            </div>
-                            <span class="text-[11px] font-bold text-[#1A1A1A]">박준서</span>
-                            <span class="text-[11px] text-[#888]">· 2026.04.05</span>
-                        </div>
-                        <p class="text-[13px] text-[#444] leading-relaxed line-clamp-2 mb-2">포즈 추천도 많이 해주시고 편안한 분위기에서 촬영할 수 있어서 좋았습니다. 보정본도 너무 맘에 들어요!</p>
-                        <div class="text-[11px] font-semibold text-[#1D3CFF]">데이트 스냅 (2인)</div>
+                        <p class="text-[13px] text-[#444] leading-relaxed line-clamp-2 mb-2" th:text="${review.content}">리뷰 내용</p>
+                        <div class="text-[11px] font-semibold text-[#1D3CFF]" th:text="${review.itemName}">서비스명</div>
                     </div>
                 </div>
+                <div th:unless="${recentReviews != null and !#lists.isEmpty(recentReviews)}"
+                     class="text-sm text-[#888] py-4 text-center">최근 등록된 후기가 없습니다.</div>
             </div>
 
         </div>

--- a/src/main/resources/templates/photographer/profile.html
+++ b/src/main/resources/templates/photographer/profile.html
@@ -97,7 +97,7 @@
               <div class="flex items-center justify-center gap-1">
                 <span class="text-xl text-[#FFB800]">★</span>
                 <span class="text-2xl font-bold text-[#1A1A1A]"
-                      th:text="${profile.reviewCount != null and profile.reviewCount > 0} ? ${#numbers.formatDecimal(profile.reviewScore * 1.0 / profile.reviewCount, 1, 1)} : '0.0'"></span>
+                      th:text="${reviewCount > 0} ? ${avgRating} : '0.0'"></span>
               </div>
             </div>
           </div>
@@ -291,14 +291,24 @@
               <span class="text-sm font-semibold text-[#888]"
                     th:text="${reviewCount > 0 ? reviewCount + '건' : ''}"></span>
             </div>
-            <div th:if="${reviewCount > 0}" class="flex items-center gap-1.5">
-              <span class="text-lg text-[#FBBF24]">★</span>
-              <span class="text-base font-bold text-[#1A1A1A]" th:text="${avgRating}">0.0</span>
+            <div class="flex items-center gap-3">
+              <div th:if="${reviewCount > 0}" class="flex items-center gap-1.5">
+                <span class="text-lg text-[#FBBF24]">★</span>
+                <span class="text-base font-bold text-[#1A1A1A]" th:text="${avgRating}">0.0</span>
+              </div>
+              <select id="photographer-review-order" class="text-sm border border-[#CCC] rounded-lg px-3 py-2 bg-white text-[#444]">
+                <option value="recent">최신순</option>
+                <option value="score-desc">별점 높은순</option>
+                <option value="score-asc">별점 낮은순</option>
+              </select>
             </div>
           </div>
 
           <!-- 후기 목록 -->
-          <div th:if="${reviewCount > 0}" class="divide-y divide-[#EEE]">
+          <div th:if="${reviewCount > 0}"
+               id="photographer-review-list"
+               class="divide-y divide-[#EEE]"
+               th:attr="data-photographer-id=${profile.photographerId},data-current-page=0,data-has-next=${reviewHasNext}">
             <article th:each="review : ${reviews}" class="py-5 first:pt-0 last:pb-0">
               <div class="flex items-start justify-between gap-4 mb-3">
                 <div class="flex items-center gap-3">
@@ -327,6 +337,13 @@
             </article>
           </div>
 
+          <button id="photographer-review-load-more"
+                  th:if="${reviewHasNext}"
+                  type="button"
+                  class="mt-4 w-full text-sm font-semibold text-[#1D3CFF] border border-[#1D3CFF] rounded-lg py-2.5 hover:bg-[#1D3CFF] hover:text-white transition-colors">
+            더 불러오기
+          </button>
+
           <!-- 빈 상태 -->
           <div th:unless="${reviewCount > 0}"
                class="rounded-xl border border-dashed border-[#CCC] bg-[#F9FAFC] px-5 py-10 text-center">
@@ -337,6 +354,65 @@
       </div>
     </div>
   </section>
+
+  <script>
+    (function () {
+      const listEl = document.getElementById('photographer-review-list');
+      const orderEl = document.getElementById('photographer-review-order');
+      const loadMoreBtn = document.getElementById('photographer-review-load-more');
+      if (!listEl || !orderEl) return;
+
+      const photographerId = listEl.dataset.photographerId;
+      let currentPage = parseInt(listEl.dataset.currentPage || '0', 10);
+      let hasNext = (listEl.dataset.hasNext || 'false') === 'true';
+      let loading = false;
+
+      const toggleLoadMore = () => {
+        if (!loadMoreBtn) return;
+        loadMoreBtn.style.display = hasNext ? 'block' : 'none';
+      };
+      toggleLoadMore();
+
+      const loadReviews = async (page, append) => {
+        if (loading) return;
+        loading = true;
+        try {
+          const url = `/review/photographer/${photographerId}/fragment?orderBy=${encodeURIComponent(orderEl.value)}&page=${page}`;
+          const res = await fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+          if (!res.ok) return;
+          const html = await res.text();
+          const temp = document.createElement('div');
+          temp.innerHTML = html;
+          const fragment = temp.querySelector('[data-has-next]');
+          if (!fragment) return;
+
+          if (append) {
+            listEl.insertAdjacentHTML('beforeend', fragment.innerHTML);
+          } else {
+            listEl.innerHTML = fragment.innerHTML;
+          }
+
+          hasNext = fragment.dataset.hasNext === 'true';
+          currentPage = page;
+          toggleLoadMore();
+        } finally {
+          loading = false;
+        }
+      };
+
+      orderEl.addEventListener('change', () => {
+        hasNext = true;
+        loadReviews(0, false);
+      });
+
+      if (loadMoreBtn) {
+        loadMoreBtn.addEventListener('click', () => {
+          if (!hasNext) return;
+          loadReviews(currentPage + 1, true);
+        });
+      }
+    })();
+  </script>
 </main>
 
 </body>

--- a/src/main/resources/templates/photographer/service-detail.html
+++ b/src/main/resources/templates/photographer/service-detail.html
@@ -86,13 +86,13 @@
             </a>
             <!-- Rating row -->
             <div class="flex items-center gap-3 mt-1 flex-wrap">
-              <span th:if="${item.reviewCount > 0}" class="flex items-center gap-1 text-sm">
+              <span th:if="${reviewCount > 0}" class="flex items-center gap-1 text-sm">
                 <span class="text-[#0097FF]">★</span>
                 <span class="font-semibold text-[#1A1A1A]"
-                      th:text="${#numbers.formatDecimal(item.reviewScore * 1.0 / item.reviewCount, 1, 2)}">4.9</span>
-                <span class="text-[#888]" th:text="'(' + ${item.reviewCount} + '개)'"></span>
+                      th:text="${avgRating}">4.9</span>
+                <span class="text-[#888]" th:text="'(' + ${reviewCount} + '개)'"></span>
               </span>
-              <span th:unless="${item.reviewCount > 0}" class="text-sm text-[#AAA]">아직 후기가 없어요</span>
+              <span th:unless="${reviewCount > 0}" class="text-sm text-[#AAA]">아직 후기가 없어요</span>
               <span class="inline-flex items-center gap-1 rounded-full border border-[#CCC] bg-[#F9FAFC] px-3 py-0.5 text-xs text-[#444]"
                     th:text="${item.itemType.name() == 'IN' ? '🏢 스튜디오 촬영' : '📍 방문 촬영'}">방문 촬영</span>
               <span class="inline-flex items-center gap-1 rounded-full border border-[#CCC] bg-[#F9FAFC] px-3 py-0.5 text-xs text-[#0097FF] font-semibold"
@@ -208,27 +208,36 @@
         <!-- 리뷰 -->
         <div class="bg-white border border-[#CCC] rounded-2xl p-6">
           <div class="flex items-center justify-between gap-3 mb-5">
-            <h2 class="text-xl font-semibold text-[#1A1A1A]">리뷰</h2>
-            <span class="text-sm text-[#888]" th:text="${item.reviewCount} + '개'">0개</span>
+            <div class="flex items-center gap-3">
+              <h2 class="text-xl font-semibold text-[#1A1A1A]">리뷰</h2>
+              <span class="text-sm text-[#888]" th:text="${reviewCount} + '개'">0개</span>
+            </div>
+            <select id="item-review-order" class="text-sm border border-[#CCC] rounded-lg px-3 py-2 bg-white text-[#444]">
+              <option value="recent">최신순</option>
+              <option value="score-desc">별점 높은순</option>
+              <option value="score-asc">별점 낮은순</option>
+            </select>
           </div>
 
-          <div th:if="${item.reviewCount > 0}">
+          <div th:if="${reviewCount > 0}">
             <!-- 요약 -->
             <div class="flex items-center gap-6 pb-5 border-b border-[#CCC]">
               <div class="text-center">
                 <p class="text-5xl font-bold text-[#1A1A1A]"
-                   th:text="${#numbers.formatDecimal(item.reviewScore * 1.0 / item.reviewCount, 1, 2)}">0.0</p>
+                   th:text="${avgRating}">0.0</p>
                 <div class="flex gap-0.5 mt-2 justify-center">
                   <span th:each="i : ${#numbers.sequence(1, 5)}"
-                        th:style="${i <= item.reviewScore * 1.0 / item.reviewCount} ? 'color:#FBBF24' : 'color:#E5E7EB'"
+                        th:style="${i <= avgRatingValue} ? 'color:#FBBF24' : 'color:#E5E7EB'"
                         class="text-lg">★</span>
                 </div>
               </div>
-              <p class="text-sm text-[#888]" th:text="'후기 ' + ${item.reviewCount} + '개'">후기 0개</p>
+              <p class="text-sm text-[#888]" th:text="'후기 ' + ${reviewCount} + '개'">후기 0개</p>
             </div>
 
             <!-- 개별 리뷰 목록 -->
-            <div class="divide-y divide-[#EEE] mt-1">
+            <div id="item-review-list"
+                 class="divide-y divide-[#EEE] mt-1"
+                 th:attr="data-item-id=${item.id},data-current-page=0,data-has-next=${reviewHasNext}">
               <article th:each="review : ${reviews}" class="py-5">
                 <div class="flex items-start justify-between gap-4 mb-3">
                   <div class="flex items-center gap-3">
@@ -246,14 +255,22 @@
                         <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
                       </svg>
                     </th:block>
+                    <span class="text-[12px] font-bold text-[#1A1A1A] ml-1" th:text="${review.rating + '.0'}">4.0</span>
                   </div>
                 </div>
                 <p class="text-[13px] text-[#444] leading-relaxed" th:text="${review.content}">후기 내용</p>
               </article>
             </div>
+
+            <button id="item-review-load-more"
+                    th:if="${reviewHasNext}"
+                    type="button"
+                    class="mt-4 w-full text-sm font-semibold text-[#1D3CFF] border border-[#1D3CFF] rounded-lg py-2.5 hover:bg-[#1D3CFF] hover:text-white transition-colors">
+              더 불러오기
+            </button>
           </div>
 
-          <div th:unless="${item.reviewCount > 0}"
+          <div th:unless="${reviewCount > 0}"
                class="rounded-xl border border-dashed border-[#CCC] bg-[#F9FAFC] px-5 py-8 text-center">
             <p class="text-base font-medium text-[#444] mb-1">아직 등록된 후기가 없어요.</p>
             <p class="text-sm text-[#888]">이 작가에게 예약 후 첫 번째 후기를 남겨보세요.</p>
@@ -427,6 +444,64 @@
         });
       });
     })();
+
+    (function () {
+      const listEl = document.getElementById('item-review-list');
+      const orderEl = document.getElementById('item-review-order');
+      const loadMoreBtn = document.getElementById('item-review-load-more');
+      if (!listEl || !orderEl) return;
+
+      const itemId = listEl.dataset.itemId;
+      let currentPage = parseInt(listEl.dataset.currentPage || '0', 10);
+      let hasNext = (listEl.dataset.hasNext || 'false') === 'true';
+      let loading = false;
+
+      const toggleLoadMore = () => {
+        if (!loadMoreBtn) return;
+        loadMoreBtn.style.display = hasNext ? 'block' : 'none';
+      };
+      toggleLoadMore();
+
+      const loadReviews = async (page, append) => {
+        if (loading) return;
+        loading = true;
+        try {
+          const url = `/review/item/${itemId}/fragment?orderBy=${encodeURIComponent(orderEl.value)}&page=${page}`;
+          const res = await fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+          if (!res.ok) return;
+          const html = await res.text();
+          const temp = document.createElement('div');
+          temp.innerHTML = html;
+          const fragment = temp.querySelector('[data-has-next]');
+          if (!fragment) return;
+
+          if (append) {
+            listEl.insertAdjacentHTML('beforeend', fragment.innerHTML);
+          } else {
+            listEl.innerHTML = fragment.innerHTML;
+          }
+
+          hasNext = fragment.dataset.hasNext === 'true';
+          currentPage = page;
+          toggleLoadMore();
+        } finally {
+          loading = false;
+        }
+      };
+
+      orderEl.addEventListener('change', () => {
+        hasNext = true;
+        loadReviews(0, false);
+      });
+
+      if (loadMoreBtn) {
+        loadMoreBtn.addEventListener('click', () => {
+          if (!hasNext) return;
+          loadReviews(currentPage + 1, true);
+        });
+      }
+    })();
+
     function selectImg(el) {
         document.getElementById('main-img').src = el.dataset.src;
         document.querySelectorAll('.thumbnail-item').forEach(t => {

--- a/src/main/resources/templates/review/item_review_fragment.html
+++ b/src/main/resources/templates/review/item_review_fragment.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div th:fragment="reviewList" th:attr="data-has-next=${hasNext}">
+  <article th:each="review : ${reviews}" class="py-5">
+    <div class="flex items-start justify-between gap-4 mb-3">
+      <div class="flex items-center gap-3">
+        <div class="w-9 h-9 rounded-full bg-[#D3DEF2] text-[#1D3CFF] flex items-center justify-center text-sm font-black shrink-0"
+             th:text="${#strings.substring(review.order.buyer.name, 0, 1)}">이</div>
+        <div>
+          <p class="text-sm font-bold text-[#1A1A1A]" th:text="${review.order.buyer.name}">이름</p>
+          <p class="text-[11px] text-[#888]" th:text="${#temporals.format(review.order.startDate, 'yyyy.MM.dd')}">날짜</p>
+        </div>
+      </div>
+      <div class="flex items-center gap-0.5 shrink-0">
+        <th:block th:each="i : ${#numbers.sequence(1, 5)}">
+          <svg class="w-3.5 h-3.5" th:style="${i <= review.score} ? 'color:#FBBF24' : 'color:#E5E7EB'"
+               fill="currentColor" viewBox="0 0 20 20">
+            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
+          </svg>
+        </th:block>
+        <span class="text-[12px] font-bold text-[#1A1A1A] ml-1" th:text="${review.score + '.0'}">4.0</span>
+      </div>
+    </div>
+    <p class="text-[13px] text-[#444] leading-relaxed" th:text="${review.description}">후기 내용</p>
+  </article>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/review/photographer_review_fragment.html
+++ b/src/main/resources/templates/review/photographer_review_fragment.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div th:fragment="reviewList" th:attr="data-has-next=${hasNext}">
+  <article th:each="review : ${reviews}" class="py-5 first:pt-0 last:pb-0">
+    <div class="flex items-start justify-between gap-4 mb-3">
+      <div class="flex items-center gap-3">
+        <div class="w-10 h-10 rounded-full bg-[#D3DEF2] text-[#1D3CFF] flex items-center justify-center text-sm font-black shrink-0"
+             th:text="${#strings.substring(review.order.buyer.name, 0, 1)}">이</div>
+        <div>
+          <p class="text-sm font-bold text-[#1A1A1A]" th:text="${review.order.buyer.name}">이름</p>
+          <p class="text-[11px] text-[#888]">
+            <span th:text="${review.order.planField['itemName'] != null ? review.order.planField['itemName'] : '서비스 #' + review.order.itemId}">서비스</span>
+            <span th:text="' · ' + ${#temporals.format(review.order.startDate, 'yyyy.MM.dd')}"></span>
+          </p>
+        </div>
+      </div>
+
+      <div class="flex items-center gap-0.5 shrink-0">
+        <th:block th:each="i : ${#numbers.sequence(1, 5)}">
+          <svg class="w-4 h-4" th:style="${i <= review.score} ? 'color:#FBBF24' : 'color:#E5E7EB'"
+               fill="currentColor" viewBox="0 0 20 20">
+            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/>
+          </svg>
+        </th:block>
+        <span class="text-[12px] font-bold text-[#1A1A1A] ml-1" th:text="${review.score + '.0'}">5.0</span>
+      </div>
+    </div>
+    <p class="text-[13px] text-[#444] leading-relaxed" th:text="${review.description}">후기 내용</p>
+  </article>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 작업 내용
리뷰 조회 명세(`/review/item/{itemId}/fragment`, `/review/photographer/{photographerId}/fragment`)에 맞춰
정렬/페이징/더불러오기 동작을 구현하고, 기존 화면과의 정합성을 보완했습니다.

## 주요 변경 사항
- 리뷰 프래그먼트 API 구현/정비
  - `GET /review/item/{itemId}/fragment`
  - `GET /review/photographer/{photographerId}/fragment`
  - 정렬 파라미터 지원: `recent`, `score-desc`, `score-asc`
  - 페이지 파라미터 기반 조회(`page=0,1,2...`) 및 `hasNext` 전달
- 비회원 리뷰 조회 허용
  - 보안 설정에서 리뷰 프래그먼트 경로 `permitAll` 적용
- 프론트 리뷰 UX 개선
  - 아이템 상세/작가 프로필에 정렬 셀렉트 + 더 불러오기 AJAX 연동
  - 초기 렌더링 시 5개만 노출되도록 조정하고 `reviewHasNext`로 버튼 노출 제어
- DTO 명세 정합성 보완
  - 기존 DTO와 충돌 방지를 위해 `review.dto.spec` 분리 유지
  - `ReviewDto -> OrderDto -> (buyer/photographer/region/plan...)` 구조 반영
- 화면 표시 보완
  - 작가 프로필 평균 별점 표시를 실제 조회 리뷰 기준으로 일치화
- 작가 대시보드 하단 `최근 후기` 영역을 하드코딩 UI에서 실제 DB 조회 기반으로 변경했습니다.
- `PhotographerDashboardController`에서 작가 리뷰를 조회해 `recentReviews` 모델로 전달하도록 수정했습니다.
- `dashboard.html`에서 `th:each`로 최근 후기(별점/작성자/날짜/내용/서비스명)를 동적으로 렌더링하도록 변경했습니다.
- `최근 후기 > 전체 보기` 링크를 후기 관리 페이지(`/photographer/{id}/reviews`)로 연결했습니다.
- 리뷰가 없을 때는 빈 상태 문구가 보이도록 처리했습니다.


## 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 관련 페이지 렌더링 확인
