### PR TITLE
fix: header 버튼 제거, 공용 헤더 미적용 파일 수정

### DIFF
--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -12,18 +12,6 @@
       <span class="font-angelica text-[16px] text-[#1D3CFF] tracking-wide">PICKASSO</span>
     </a>
 
-    <!-- 네비게이션 (md 이상) -->
-    <nav class="hidden md:flex items-center gap-8">
-      <a th:href="@{/search}"
-         class="text-[15px] font-medium text-[#444] hover:text-[#1D3CFF] transition-colors no-underline">
-        촬영 매칭
-      </a>
-      <a th:href="@{/}"
-         class="text-[15px] font-medium text-[#444] hover:text-[#1D3CFF] transition-colors no-underline">
-        포트폴리오 검색
-      </a>
-    </nav>
-
     <!-- 인증 영역 -->
     <div class="flex items-center gap-3">
 

--- a/src/main/resources/templates/photographer/service-register.html
+++ b/src/main/resources/templates/photographer/service-register.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6" lang="ko">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -25,30 +26,7 @@
 </head>
 <body class="bg-[#F9FAFC] font-sans text-[#1A1A1A]">
 
-<!-- ─── HEADER ──────────────────────────────── -->
-<header class="sticky top-0 z-50 bg-[#F9FAFC] border-b border-[#1A1A1A] h-[68px] flex items-center">
-  <div class="max-w-[1216px] w-full mx-auto px-6 flex items-center justify-between">
-    <a th:href="@{/}" class="flex items-center gap-2 no-underline">
-      <div class="w-[34px] h-[34px] rounded-full bg-[conic-gradient(from_0deg,#1D3CFF,#0097FF,#1D3CFF)] flex-shrink-0"></div>
-      <span class="font-angelica text-[22px] text-[#1D3CFF] tracking-wide">PICKASSO</span>
-    </a>
-    <div class="flex items-center gap-3">
-    <span class="text-[15px] font-semibold text-[#444]"
-          th:text="${itemRegisterRequest.name == null} ? '서비스 등록' : '서비스 수정'">서비스 등록</span>
-      <button type="button"
-              class="flex items-center gap-1.5 text-sm font-semibold text-[#444] bg-white border border-[#CCC] rounded-lg px-4 py-2 hover:border-[#1D3CFF] hover:text-[#1D3CFF] transition-colors">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/>
-        </svg>
-        미리보기
-      </button>
-      <button type="button" id="btn-temp-save"
-              class="text-sm font-bold text-[#1D3CFF] bg-white border-[1.5px] border-[#1D3CFF] rounded-lg px-5 py-2 hover:bg-[#1D3CFF] hover:text-white transition-colors">
-        임시저장
-      </button>
-    </div>
-  </div>
-</header>
+<th:block th:replace="~{fragments/header :: header}" />
 
 <!-- ─── STEP NAV ─────────────────────────────── -->
 <nav class="bg-white border-b border-[#CCC] sticky top-[68px] z-40">

--- a/src/main/resources/templates/user/reservation.html
+++ b/src/main/resources/templates/user/reservation.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org" lang="ko">
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity6" lang="ko">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -68,27 +69,7 @@
 </head>
 <body class="bg-[#F9FAFC] text-[#1A1A1A] font-sans">
 
-<!-- ─── 헤더 ─────────────────────────────────────────── -->
-<header class="sticky top-0 z-50 bg-[#F9FAFC] border-b border-[#1A1A1A] h-16 flex items-center">
-  <div class="max-w-[1216px] w-full mx-auto px-6 flex items-center justify-between">
-    <a th:href="@{/}" class="flex items-center gap-2">
-      <img th:src="@{/images/logo.png}" alt="PICKASSO 로고" class="h-8 w-auto">
-      <span class="font-angelica text-[16px] text-[#1D3CFF] tracking-wide">PICKASSO</span>
-    </a>
-
-    <nav class="flex items-center gap-1.5 text-sm" aria-label="예약 흐름">
-      <a th:href="@{/item/{id}(id=${item.id})}" class="text-[#888] hover:text-[#1D3CFF] transition-colors"
-         th:text="${item.name}">서비스 상세</a>
-      <span class="text-[#CCC]">›</span>
-      <span class="font-semibold text-[#1D3CFF]">예약하기</span>
-    </nav>
-
-    <button type="button"
-            class="text-sm font-medium border border-[#CCC] text-[#444] px-4 py-2 rounded-lg hover:border-[#888] hover:text-[#1A1A1A] transition-colors">
-      문의하기
-    </button>
-  </div>
-</header>
+<th:block th:replace="~{fragments/header :: header}" />
 
 <!-- ─── 스텝 진행 표시 ─────────────────────────────────── -->
 <div class="bg-white border-b border-[#CCC]">


### PR DESCRIPTION
## 작업 내용
- 헤더 수정

## 변경 사항
- 공용 헤더 미적용이던 `user/reservation.html`, `photographer/service-register.html` 파일 수정해 헤더 적용
- 헤더 내부 사용하지 않는 버튼 제거 

## 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 관련 페이지 렌더링 확인
